### PR TITLE
refactor gentraceback into iterator style

### DIFF
--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+var go121UseGentraceback2 = true
+
 // The code in this file implements stack trace walking for all architectures.
 // The most important fact about a given architecture is whether it uses a link register.
 // On systems with link registers, the prologue for a non-leaf function stores the
@@ -30,6 +32,10 @@ const usesLR = sys.MinFrameSize > 0
 // of logical frames to skip rather than physical frames (with inlining, a
 // PC in pcbuf can represent multiple calls).
 func gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+	if go121UseGentraceback2 {
+		return gentraceback2(pc0, sp0, lr0, gp, skip, pcbuf, max, callback, v, flags)
+	}
+
 	if skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -310,8 +310,6 @@ yield:
 			switch itr.event = itr.postamble(); itr.event {
 			case eventOK:
 				itr.state = statePreambleFrame
-				foundFrame = true
-				break yield
 			case eventBottomOfStack, eventMaxReached:
 				itr.state = stateDone
 			default:
@@ -321,6 +319,7 @@ yield:
 
 		case stateDone, stateError:
 			break yield
+
 		default:
 			throw("bug")
 		}
@@ -571,10 +570,9 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 		if itr.inldata != nil {
 			return eventPCBufInline
 		}
-		return eventBufNormal
 	}
 
-	return eventNoPCBuf
+	return eventBufNormal
 }
 
 func (itr *tracebackIterator) inlineFrame() tracebackEvent {
@@ -604,6 +602,10 @@ func (itr *tracebackIterator) inlineFrame() tracebackEvent {
 }
 
 func (itr *tracebackIterator) normalFrame() tracebackEvent {
+	if itr.pcbuf == nil {
+		return eventOK
+	}
+
 	f := itr.frame.fn
 
 	// Record the main frame.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -268,6 +268,7 @@ yield:
 				itr.state = stateError
 				break yield
 			}
+
 		case statePrepareFrame:
 			switch itr.event = itr.prepareFrame(); itr.event {
 			case eventPCBufInline:
@@ -280,16 +281,22 @@ yield:
 				itr.state = stateError
 				break yield
 			}
+
 		case stateBufInlineFrame:
 			switch itr.event = itr.inlineFrame(); itr.event {
 			case eventPCBufInline:
 				itr.state = stateBufInlineFrame
+				more = true
+				break yield
 			case eventBufNormal:
 				itr.state = stateBufNormalFrame
+				more = true
+				break yield
 			default:
 				itr.state = stateError
 				break yield
 			}
+
 		case stateBufNormalFrame:
 			switch itr.event = itr.normalFrame(); itr.event {
 			case eventOK:
@@ -298,6 +305,7 @@ yield:
 				itr.state = stateError
 				break yield
 			}
+
 		case statePostamble:
 			switch itr.event = itr.next(); itr.event {
 			case eventOK:
@@ -310,6 +318,7 @@ yield:
 				itr.state = stateError
 				break yield
 			}
+
 		case stateDone, stateError:
 			break yield
 		default:

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -20,7 +20,6 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		pcbuf:    pcbuf,
 		max:      max,
 		callback: *(*func(*stkframe, unsafe.Pointer) bool)(noescape(unsafe.Pointer(&callback))),
-		v:        v,
 		flags:    flags,
 	}
 	if !itr.init() {
@@ -28,6 +27,11 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	}
 
 	for itr.Next() {
+		if callback != nil {
+			if !callback((*stkframe)(noescape(unsafe.Pointer(itr.Frame()))), v) {
+				return itr.n
+			}
+		}
 	}
 
 	if itr.callbackAbort {
@@ -94,7 +98,6 @@ type tracebackIterator struct {
 	pcbuf         *uintptr
 	max           int
 	callback      func(*stkframe, unsafe.Pointer) bool
-	v             unsafe.Pointer
 	flags         uint
 
 	level         int32
@@ -108,6 +111,7 @@ type tracebackIterator struct {
 	lastFuncID    funcID
 	n             int
 	callbackAbort bool
+	currentFrame  stkframe // frame is already the next frame when Next() returns
 }
 
 func (itr *tracebackIterator) init() bool {
@@ -418,12 +422,15 @@ func (itr *tracebackIterator) Next() bool {
 		}
 	}
 
-	if itr.callback != nil {
-		if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
-			itr.callbackAbort = true
-			return false
-		}
-	}
+	// TODO(fg) remove this hack
+	setFuncInfoNoWB(&itr.currentFrame.fn, itr.frame.fn)
+	itr.currentFrame.pc = itr.frame.pc
+	itr.currentFrame.continpc = itr.frame.continpc
+	itr.currentFrame.lr = itr.frame.lr
+	itr.currentFrame.sp = itr.frame.sp
+	itr.currentFrame.fp = itr.frame.fp
+	itr.currentFrame.varp = itr.frame.varp
+	itr.currentFrame.argp = itr.frame.argp
 
 	if itr.pcbuf != nil {
 		pc := itr.frame.pc
@@ -599,6 +606,10 @@ func (itr *tracebackIterator) Next() bool {
 		}
 	}
 	return itr.n < itr.max
+}
+
+func (itr *tracebackIterator) Frame() *stkframe {
+	return &itr.currentFrame
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -21,9 +21,9 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		max:      max,
 		callback: callback,
 		v:        v,
-		// flags:    flags,
+		flags:    flags,
 	}
-	return itr.Gentraceback(flags)
+	return itr.Gentraceback()
 }
 
 type tracebackIterator struct {
@@ -37,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(flags uint) int {
+func (itr *tracebackIterator) Gentraceback() int {
 	if itr.skip > 0 && itr.callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -170,7 +170,7 @@ func (itr *tracebackIterator) Gentraceback(flags uint) int {
 			// We also defensively check that this won't switch M's on us,
 			// which could happen at critical points in the scheduler.
 			// This ensures gp.m doesn't change from a stack jump.
-			if flags&_TraceJumpStack != 0 && itr.gp == itr.gp.m.g0 && itr.gp.m.curg != nil && itr.gp.m.curg.m == itr.gp.m {
+			if itr.flags&_TraceJumpStack != 0 && itr.gp == itr.gp.m.g0 && itr.gp.m.curg != nil && itr.gp.m.curg.m == itr.gp.m {
 				switch f.funcID {
 				case funcID_morestack:
 					// morestack does not return normally -- newstack()
@@ -357,7 +357,7 @@ func (itr *tracebackIterator) Gentraceback(flags uint) int {
 			// See issue 34123.
 			// The pc can be at function entry when the frame is initialized without
 			// actually running code, like runtime.mstart.
-			if (n == 0 && flags&_TraceTrap != 0) || waspanic || pc == f.entry() {
+			if (n == 0 && itr.flags&_TraceTrap != 0) || waspanic || pc == f.entry() {
 				pc++
 			} else {
 				tracepc--
@@ -408,7 +408,7 @@ func (itr *tracebackIterator) Gentraceback(flags uint) int {
 
 			// backup to CALL instruction to read inlining info (same logic as below)
 			tracepc := frame.pc
-			if (n > 0 || flags&_TraceTrap == 0) && frame.pc > f.entry() && !waspanic {
+			if (n > 0 || itr.flags&_TraceTrap == 0) && frame.pc > f.entry() && !waspanic {
 				tracepc--
 			}
 			// If there is inlining info, print the inner frames.
@@ -428,7 +428,7 @@ func (itr *tracebackIterator) Gentraceback(flags uint) int {
 					inlFunc.funcID = inltree[ix].funcID
 					inlFunc.startLine = inltree[ix].startLine
 
-					if (flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, nprint == 0, inlFuncInfo.funcID, lastFuncID) {
+					if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, nprint == 0, inlFuncInfo.funcID, lastFuncID) {
 						name := funcname(inlFuncInfo)
 						file, line := funcline(f, tracepc)
 						print(name, "(...)\n")
@@ -440,7 +440,7 @@ func (itr *tracebackIterator) Gentraceback(flags uint) int {
 					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
 				}
 			}
-			if (flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, nprint == 0, f.funcID, lastFuncID) {
+			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, nprint == 0, f.funcID, lastFuncID) {
 				// Print during crash.
 				//	main(0x1, 0x2, 0x3)
 				//		/home/rsc/go/src/runtime/x.go:23 +0xf

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -12,18 +12,18 @@ import (
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	itr := tracebackIterator{
-		pc0: pc0,
-		sp0: sp0,
-		lr0: lr0,
-		gp:  gp,
-		// skip:     skip,
+		pc0:  pc0,
+		sp0:  sp0,
+		lr0:  lr0,
+		gp:   gp,
+		skip: skip,
 		// pcbuf:    pcbuf,
 		// max:      max,
 		// callback: callback,
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(skip, pcbuf, max, callback, v, flags)
+	return itr.Gentraceback(pcbuf, max, callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,8 +37,8 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
-	if skip > 0 && callback != nil {
+func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+	if itr.skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
 
@@ -373,8 +373,8 @@ func (itr *tracebackIterator) Gentraceback(skip int, pcbuf *uintptr, max int, ca
 					}
 					if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(lastFuncID) {
 						// ignore wrappers
-					} else if skip > 0 {
-						skip--
+					} else if itr.skip > 0 {
+						itr.skip--
 					} else if n < max {
 						(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = pc
 						n++
@@ -388,8 +388,8 @@ func (itr *tracebackIterator) Gentraceback(skip int, pcbuf *uintptr, max int, ca
 			// Record the main frame.
 			if f.funcID == funcID_wrapper && elideWrapperCalling(lastFuncID) {
 				// Ignore wrapper functions (except when they trigger panics).
-			} else if skip > 0 {
-				skip--
+			} else if itr.skip > 0 {
+				itr.skip--
 			} else if n < max {
 				(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = pc
 				n++
@@ -475,7 +475,7 @@ func (itr *tracebackIterator) Gentraceback(skip int, pcbuf *uintptr, max int, ca
 			// skip only applies to Go frames.
 			// callback != nil only used when we only care
 			// about Go frames.
-			if skip == 0 && callback == nil {
+			if itr.skip == 0 && callback == nil {
 				n = tracebackCgoContext(pcbuf, printing, ctxt, n, max)
 			}
 		}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -15,8 +15,8 @@ type tracebackState int
 const (
 	stateInit tracebackState = iota
 	statePreambleFrame
-	stateBufInlineFrame
-	stateBufNormalFrame
+	stateYieldInlineFrame
+	stateYieldNormalFrame
 	statePostamble
 	stateDone
 	stateError
@@ -256,7 +256,7 @@ func (itr *tracebackIterator) init() tracebackEvent {
 	return eventOK
 }
 
-func (itr *tracebackIterator) Next() (more bool) {
+func (itr *tracebackIterator) Next() (foundFrame bool) {
 yield:
 	for {
 		switch itr.state {
@@ -272,9 +272,9 @@ yield:
 		case statePreambleFrame:
 			switch itr.event = itr.preamble(); itr.event {
 			case eventPCBufInline:
-				itr.state = stateBufInlineFrame
+				itr.state = stateYieldInlineFrame
 			case eventBufNormal:
-				itr.state = stateBufNormalFrame
+				itr.state = stateYieldNormalFrame
 			case eventNoPCBuf:
 				itr.state = statePostamble
 			default:
@@ -282,25 +282,25 @@ yield:
 				break yield
 			}
 
-		case stateBufInlineFrame:
+		case stateYieldInlineFrame:
 			switch itr.event = itr.inlineFrame(); itr.event {
 			case eventPCBufInline:
-				itr.state = stateBufInlineFrame
-				more = true
+				itr.state = stateYieldInlineFrame
+				foundFrame = true
 				break yield
 			case eventBufNormal:
-				itr.state = stateBufNormalFrame
-				more = true
-				break yield
+				itr.state = stateYieldNormalFrame
 			default:
 				itr.state = stateError
 				break yield
 			}
 
-		case stateBufNormalFrame:
+		case stateYieldNormalFrame:
 			switch itr.event = itr.normalFrame(); itr.event {
 			case eventOK:
 				itr.state = statePostamble
+				foundFrame = true
+				break yield
 			default:
 				itr.state = stateError
 				break yield
@@ -310,7 +310,7 @@ yield:
 			switch itr.event = itr.postamble(); itr.event {
 			case eventOK:
 				itr.state = statePreambleFrame
-				more = true
+				foundFrame = true
 				break yield
 			case eventBottomOfStack, eventMaxReached:
 				itr.state = stateDone
@@ -325,7 +325,7 @@ yield:
 			throw("bug")
 		}
 	}
-	return more
+	return foundFrame
 }
 
 func (itr *tracebackIterator) preamble() tracebackEvent {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -12,18 +12,18 @@ import (
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	itr := tracebackIterator{
-		pc0:   pc0,
-		sp0:   sp0,
-		lr0:   lr0,
-		gp:    gp,
-		skip:  skip,
-		pcbuf: pcbuf,
-		max:   max,
-		// callback: callback,
+		pc0:      pc0,
+		sp0:      sp0,
+		lr0:      lr0,
+		gp:       gp,
+		skip:     skip,
+		pcbuf:    pcbuf,
+		max:      max,
+		callback: callback,
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(callback, v, flags)
+	return itr.Gentraceback(v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,8 +37,8 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
-	if itr.skip > 0 && callback != nil {
+func (itr *tracebackIterator) Gentraceback(v unsafe.Pointer, flags uint) int {
+	if itr.skip > 0 && itr.callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
 
@@ -87,7 +87,7 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 	waspanic := false
 	cgoCtxt := itr.gp.cgoCtxt
 	stack := itr.gp.stack
-	printing := itr.pcbuf == nil && callback == nil
+	printing := itr.pcbuf == nil && itr.callback == nil
 
 	// If the PC is zero, it's likely a nil function call.
 	// Start in the caller's frame.
@@ -117,11 +117,11 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 
 	f := findfunc(frame.pc)
 	if !f.valid() {
-		if callback != nil || printing {
+		if itr.callback != nil || printing {
 			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(frame.pc), "\n")
 			tracebackHexdump(stack, &frame, 0)
 		}
-		if callback != nil {
+		if itr.callback != nil {
 			throw("unknown pc")
 		}
 		return 0
@@ -219,7 +219,7 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 			// This function marks the top of the stack. Stop the traceback.
 			frame.lr = 0
 			flr = funcInfo{}
-		} else if flag&funcFlag_SPWRITE != 0 && (callback == nil || n > 0) {
+		} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || n > 0) {
 			// The function we are in does a write to SP that we don't know
 			// how to encode in the spdelta table. Examples include context
 			// switch routines like runtime.gogo but also any code that switches
@@ -237,7 +237,7 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 			// So for GC stack traversal we leave things alone (this if body does not execute for n == 0)
 			// at the bottom frame of the stack. But farther up the stack we'd better not
 			// find any.
-			if callback != nil {
+			if itr.callback != nil {
 				println("traceback: unexpected SPWRITE function", funcname(f))
 				throw("traceback")
 			}
@@ -270,11 +270,11 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 					// return PC. Don't complain.
 					doPrint = false
 				}
-				if callback != nil || doPrint {
+				if itr.callback != nil || doPrint {
 					print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(frame.lr), "\n")
 					tracebackHexdump(stack, &frame, lrPtr)
 				}
-				if callback != nil {
+				if itr.callback != nil {
 					throw("unknown caller pc")
 				}
 			}
@@ -336,8 +336,8 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 			}
 		}
 
-		if callback != nil {
-			if !callback((*stkframe)(noescape(unsafe.Pointer(&frame))), v) {
+		if itr.callback != nil {
+			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&frame))), v) {
 				return n
 			}
 		}
@@ -475,7 +475,7 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 			// skip only applies to Go frames.
 			// callback != nil only used when we only care
 			// about Go frames.
-			if itr.skip == 0 && callback == nil {
+			if itr.skip == 0 && itr.callback == nil {
 				n = tracebackCgoContext(itr.pcbuf, printing, ctxt, n, itr.max)
 			}
 		}
@@ -561,7 +561,7 @@ func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Point
 	// At other times, such as when gathering a stack for a profiling signal
 	// or when printing a traceback during a crash, everything may not be
 	// stopped nicely, and the stack walk may not be able to complete.
-	if callback != nil && n < itr.max && frame.sp != itr.gp.stktopsp {
+	if itr.callback != nil && n < itr.max && frame.sp != itr.gp.stktopsp {
 		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
 		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", n, " max=", itr.max, "\n")
 		throw("traceback did not unwind completely")

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -36,6 +36,8 @@ type tracebackIterator struct {
 	callback      func(*stkframe, unsafe.Pointer) bool
 	v             unsafe.Pointer
 	flags         uint
+
+	level int32
 }
 
 func (itr *tracebackIterator) init() {
@@ -60,10 +62,7 @@ func (itr *tracebackIterator) init() {
 		// instead on the g0 stack.
 		throw("gentraceback cannot trace user goroutine on its own stack")
 	}
-}
-
-func (itr *tracebackIterator) Gentraceback() int {
-	level, _, _ := gotraceback()
+	itr.level, _, _ = gotraceback()
 
 	if itr.pc0 == ^uintptr(0) && itr.sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
 		if itr.gp.syscallsp != 0 {
@@ -80,6 +79,9 @@ func (itr *tracebackIterator) Gentraceback() int {
 			}
 		}
 	}
+}
+
+func (itr *tracebackIterator) Gentraceback() int {
 
 	nprint := 0
 	var frame stkframe
@@ -462,7 +464,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 				if frame.pc > f.entry() {
 					print(" +", hex(frame.pc-f.entry()))
 				}
-				if itr.gp.m != nil && itr.gp.m.throwing >= throwTypeRuntime && itr.gp == itr.gp.m.curg || level >= 2 {
+				if itr.gp.m != nil && itr.gp.m.throwing >= throwTypeRuntime && itr.gp == itr.gp.m.curg || itr.level >= 2 {
 					print(" fp=", hex(frame.fp), " sp=", hex(frame.sp), " pc=", hex(frame.pc))
 				}
 				print("\n")

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -43,6 +43,7 @@ type tracebackIterator struct {
 	waspanic bool
 	cgoCtxt  []uintptr
 	stack    stack
+	printing bool
 }
 
 func (itr *tracebackIterator) init() {
@@ -95,11 +96,11 @@ func (itr *tracebackIterator) init() {
 	itr.waspanic = false
 	setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 	itr.stack = itr.gp.stack
+	itr.printing = itr.pcbuf == nil && itr.callback == nil
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
 	frame := itr.frame
-	printing := itr.pcbuf == nil && itr.callback == nil
 
 	// If the PC is zero, it's likely a nil function call.
 	// Start in the caller's frame.
@@ -129,7 +130,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 	f := findfunc(frame.pc)
 	if !f.valid() {
-		if itr.callback != nil || printing {
+		if itr.callback != nil || itr.printing {
 			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(frame.pc), "\n")
 			tracebackHexdump(itr.stack, &frame, 0)
 		}
@@ -274,7 +275,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 				// In that context it is okay to stop early.
 				// But if callback is set, we're doing a garbage collection and must
 				// get everything, so crash loudly.
-				doPrint := printing
+				doPrint := itr.printing
 				if doPrint && itr.gp.m.incgo && f.funcID == funcID_sigpanic {
 					// We can inject sigpanic
 					// calls directly into C code,
@@ -410,7 +411,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			n-- // offset n++ below
 		}
 
-		if printing {
+		if itr.printing {
 			// assume skip=0 for printing.
 			//
 			// Never elide wrappers if we haven't printed
@@ -488,7 +489,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// callback != nil only used when we only care
 			// about Go frames.
 			if itr.skip == 0 && itr.callback == nil {
-				n = tracebackCgoContext(itr.pcbuf, printing, ctxt, n, itr.max)
+				n = tracebackCgoContext(itr.pcbuf, itr.printing, ctxt, n, itr.max)
 			}
 		}
 
@@ -529,7 +530,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 		}
 	}
 
-	if printing {
+	if itr.printing {
 		n = itr.nprint
 	}
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -36,7 +36,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		skip:     skip,
 		pcbuf:    pcbuf,
 		max:      max,
-		callback: *(*func(*stkframe, unsafe.Pointer) bool)(noescape(unsafe.Pointer(&callback))),
+		callback: callback != nil,
 		flags:    flags,
 		printing: printing,
 	}
@@ -123,7 +123,7 @@ type tracebackIterator struct {
 	skip          int
 	pcbuf         *uintptr
 	max           int
-	callback      func(*stkframe, unsafe.Pointer) bool
+	callback      bool
 	flags         uint
 
 	initialized  bool
@@ -327,7 +327,7 @@ func (itr *tracebackIterator) Next() bool {
 		// This function marks the top of the stack. Stop the traceback.
 		itr.frame.lr = 0
 		flr = funcInfo{}
-	} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || itr.n > 0) {
+	} else if flag&funcFlag_SPWRITE != 0 && (!itr.callback || itr.n > 0) {
 		// The function we are in does a write to SP that we don't know
 		// how to encode in the spdelta table. Examples include context
 		// switch routines like runtime.gogo but also any code that switches
@@ -345,7 +345,7 @@ func (itr *tracebackIterator) Next() bool {
 		// So for GC stack traversal we leave things alone (this if body does not execute for n == 0)
 		// at the bottom frame of the stack. But farther up the stack we'd better not
 		// find any.
-		if itr.callback != nil {
+		if itr.callback {
 			println("traceback: unexpected SPWRITE function", funcname(f))
 			throw("traceback")
 		}
@@ -378,11 +378,11 @@ func (itr *tracebackIterator) Next() bool {
 				// return PC. Don't complain.
 				doPrint = false
 			}
-			if itr.callback != nil || doPrint {
+			if itr.callback || doPrint {
 				print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(itr.frame.lr), "\n")
 				tracebackHexdump(itr.stack, &itr.frame, lrPtr)
 			}
-			if itr.callback != nil {
+			if itr.callback {
 				throw("unknown caller pc")
 			}
 		}
@@ -587,7 +587,7 @@ func (itr *tracebackIterator) Next() bool {
 		// skip only applies to Go frames.
 		// callback != nil only used when we only care
 		// about Go frames.
-		if itr.skip == 0 && itr.callback == nil {
+		if itr.skip == 0 && !itr.callback {
 			itr.n = tracebackCgoContext(itr.pcbuf, itr.printing, ctxt, itr.n, itr.max)
 		}
 	}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -23,6 +23,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		v:        v,
 		flags:    flags,
 	}
+	itr.init()
 	return itr.Gentraceback()
 }
 
@@ -37,7 +38,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback() int {
+func (itr *tracebackIterator) init() {
 	if itr.skip > 0 && itr.callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -59,6 +60,9 @@ func (itr *tracebackIterator) Gentraceback() int {
 		// instead on the g0 stack.
 		throw("gentraceback cannot trace user goroutine on its own stack")
 	}
+}
+
+func (itr *tracebackIterator) Gentraceback() int {
 	level, _, _ := gotraceback()
 
 	if itr.pc0 == ^uintptr(0) && itr.sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -111,6 +111,10 @@ type tracebackIterator struct {
 }
 
 func (itr *tracebackIterator) init() bool {
+	if itr.callback != nil && itr.pcbuf != nil {
+		throw("unexpected: callback and pcbuf set")
+	}
+
 	if itr.skip > 0 && itr.callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -36,6 +36,7 @@ const (
 	eventUnexpectedSPWrite
 	eventUnexpectedReturnPC
 	eventStuck
+	eventBottomOfStack
 )
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
@@ -256,7 +257,7 @@ func (itr *tracebackIterator) init() tracebackEvent {
 }
 
 func (itr *tracebackIterator) Next() (more bool) {
-loop:
+yield:
 	for {
 		switch itr.state {
 		case stateInit:
@@ -265,7 +266,7 @@ loop:
 				itr.state = statePrepareFrame
 			default:
 				itr.state = stateError
-				break loop
+				break yield
 			}
 		case statePrepareFrame:
 			switch itr.event = itr.prepareFrame(); itr.event {
@@ -277,7 +278,7 @@ loop:
 				itr.state = statePostamble
 			default:
 				itr.state = stateError
-				break loop
+				break yield
 			}
 		case stateBufInlineFrame:
 			switch itr.event = itr.inlineFrame(); itr.event {
@@ -287,7 +288,7 @@ loop:
 				itr.state = stateBufNormalFrame
 			default:
 				itr.state = stateError
-				break loop
+				break yield
 			}
 		case stateBufNormalFrame:
 			switch itr.event = itr.normalFrame(); itr.event {
@@ -295,18 +296,22 @@ loop:
 				itr.state = statePostamble
 			default:
 				itr.state = stateError
-				break loop
+				break yield
 			}
 		case statePostamble:
-			more = itr.next()
-			if more {
+			switch itr.event = itr.next(); itr.event {
+			case eventOK:
 				itr.state = statePrepareFrame
-			} else {
+				more = true
+				break yield
+			case eventBottomOfStack, eventMaxReached:
 				itr.state = stateDone
+			default:
+				itr.state = stateError
+				break yield
 			}
-			break loop
 		case stateDone, stateError:
-			break loop
+			break yield
 		default:
 			throw("bug")
 		}
@@ -607,7 +612,7 @@ func (itr *tracebackIterator) normalFrame() tracebackEvent {
 	return eventOK
 }
 
-func (itr *tracebackIterator) next() bool {
+func (itr *tracebackIterator) next() tracebackEvent {
 	f := itr.frame.fn
 	if itr.printing {
 		// assume skip=0 for printing.
@@ -696,7 +701,7 @@ func (itr *tracebackIterator) next() bool {
 
 	// Do not unwind past the bottom of the stack.
 	if !itr.flr.valid() {
-		return false
+		return eventBottomOfStack
 	}
 
 	if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
@@ -726,7 +731,10 @@ func (itr *tracebackIterator) next() bool {
 			itr.frame.lr = x
 		}
 	}
-	return itr.n < itr.max
+	if itr.n < itr.max {
+		return eventOK
+	}
+	return eventMaxReached
 }
 
 func (itr *tracebackIterator) Frame() *stkframe {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -211,14 +211,13 @@ func (itr *tracebackIterator) Next() bool {
 		return false
 	}
 
-	f := itr.frame.fn
 	// Typically:
 	//	pc is the PC of the running function.
 	//	sp is the stack pointer at that program counter.
 	//	fp is the frame pointer (caller's stack pointer) at that program counter, or nil if unknown.
 	//	stk is the stack containing sp.
 	//	The caller's program counter is lr, unless lr is zero, in which case it is *(uintptr*)sp.
-	f = itr.frame.fn
+	f := itr.frame.fn
 	if f.pcsp == 0 {
 		// No frame information, must be external function, like race support.
 		// See golang.org/issue/13568.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -142,7 +142,6 @@ func (itr *tracebackIterator) init() bool {
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
-	frame := itr.frame
 	f := itr.frame.fn
 
 	var cache pcvalueCache
@@ -156,7 +155,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 		//	fp is the frame pointer (caller's stack pointer) at that program counter, or nil if unknown.
 		//	stk is the stack containing sp.
 		//	The caller's program counter is lr, unless lr is zero, in which case it is *(uintptr*)sp.
-		f = frame.fn
+		f = itr.frame.fn
 		if f.pcsp == 0 {
 			// No frame information, must be external function, like race support.
 			// See golang.org/issue/13568.
@@ -172,7 +171,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// So we don't need to exclude it with the other SP-writing functions.
 			flag &^= funcFlag_SPWRITE
 		}
-		if frame.pc == itr.pc0 && frame.sp == itr.sp0 && itr.pc0 == itr.gp.syscallpc && itr.sp0 == itr.gp.syscallsp {
+		if itr.frame.pc == itr.pc0 && itr.frame.sp == itr.sp0 && itr.pc0 == itr.gp.syscallpc && itr.sp0 == itr.gp.syscallsp {
 			// Some Syscall functions write to SP, but they do so only after
 			// saving the entry PC/SP using entersyscall.
 			// Since we are using the entry PC/SP, the later SP write doesn't matter.
@@ -181,7 +180,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 		// Found an actual function.
 		// Derive frame pointer and link register.
-		if frame.fp == 0 {
+		if itr.frame.fp == 0 {
 			// Jump over system stack transitions. If we're on g0 and there's a user
 			// goroutine, try to jump. Otherwise this is a regular call.
 			// We also defensively check that this won't switch M's on us,
@@ -196,18 +195,18 @@ func (itr *tracebackIterator) Gentraceback() int {
 					// but that makes some sense since it'll never be returned
 					// to.
 					setGNoWB(&itr.gp, itr.gp.m.curg)
-					frame.pc = itr.gp.sched.pc
-					frame.fn = findfunc(frame.pc)
-					f = frame.fn
+					itr.frame.pc = itr.gp.sched.pc
+					setFuncInfoNoWB(&itr.frame.fn, findfunc(itr.frame.pc))
+					f = itr.frame.fn
 					flag = f.flag
-					frame.lr = itr.gp.sched.lr
-					frame.sp = itr.gp.sched.sp
+					itr.frame.lr = itr.gp.sched.lr
+					itr.frame.sp = itr.gp.sched.sp
 					itr.stack = itr.gp.stack
 					setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 				case funcID_systemstack:
 					// systemstack returns normally, so just follow the
 					// stack transition.
-					if usesLR && funcspdelta(f, frame.pc, &cache) == 0 {
+					if usesLR && funcspdelta(f, itr.frame.pc, &cache) == 0 {
 						// We're at the function prologue and the stack
 						// switch hasn't happened, or epilogue where we're
 						// about to return. Just unwind normally.
@@ -219,22 +218,22 @@ func (itr *tracebackIterator) Gentraceback() int {
 						break
 					}
 					setGNoWB(&itr.gp, itr.gp.m.curg)
-					frame.sp = itr.gp.sched.sp
+					itr.frame.sp = itr.gp.sched.sp
 					itr.stack = itr.gp.stack
 					setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 					flag &^= funcFlag_SPWRITE
 				}
 			}
-			frame.fp = frame.sp + uintptr(funcspdelta(f, frame.pc, &cache))
+			itr.frame.fp = itr.frame.sp + uintptr(funcspdelta(f, itr.frame.pc, &cache))
 			if !usesLR {
 				// On x86, call instruction pushes return PC before entering new function.
-				frame.fp += goarch.PtrSize
+				itr.frame.fp += goarch.PtrSize
 			}
 		}
 		var flr funcInfo
 		if flag&funcFlag_TOPFRAME != 0 {
 			// This function marks the top of the stack. Stop the traceback.
-			frame.lr = 0
+			itr.frame.lr = 0
 			flr = funcInfo{}
 		} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || n > 0) {
 			// The function we are in does a write to SP that we don't know
@@ -258,22 +257,22 @@ func (itr *tracebackIterator) Gentraceback() int {
 				println("traceback: unexpected SPWRITE function", funcname(f))
 				throw("traceback")
 			}
-			frame.lr = 0
+			itr.frame.lr = 0
 			flr = funcInfo{}
 		} else {
 			var lrPtr uintptr
 			if usesLR {
-				if n == 0 && frame.sp < frame.fp || frame.lr == 0 {
-					lrPtr = frame.sp
-					frame.lr = *(*uintptr)(unsafe.Pointer(lrPtr))
+				if n == 0 && itr.frame.sp < itr.frame.fp || itr.frame.lr == 0 {
+					lrPtr = itr.frame.sp
+					itr.frame.lr = *(*uintptr)(unsafe.Pointer(lrPtr))
 				}
 			} else {
-				if frame.lr == 0 {
-					lrPtr = frame.fp - goarch.PtrSize
-					frame.lr = uintptr(*(*uintptr)(unsafe.Pointer(lrPtr)))
+				if itr.frame.lr == 0 {
+					lrPtr = itr.frame.fp - goarch.PtrSize
+					itr.frame.lr = uintptr(*(*uintptr)(unsafe.Pointer(lrPtr)))
 				}
 			}
-			flr = findfunc(frame.lr)
+			flr = findfunc(itr.frame.lr)
 			if !flr.valid() {
 				// This happens if you get a profiling interrupt at just the wrong time.
 				// In that context it is okay to stop early.
@@ -288,8 +287,8 @@ func (itr *tracebackIterator) Gentraceback() int {
 					doPrint = false
 				}
 				if itr.callback != nil || doPrint {
-					print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(frame.lr), "\n")
-					tracebackHexdump(itr.stack, &frame, lrPtr)
+					print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(itr.frame.lr), "\n")
+					tracebackHexdump(itr.stack, &itr.frame, lrPtr)
 				}
 				if itr.callback != nil {
 					throw("unknown caller pc")
@@ -297,10 +296,10 @@ func (itr *tracebackIterator) Gentraceback() int {
 			}
 		}
 
-		frame.varp = frame.fp
+		itr.frame.varp = itr.frame.fp
 		if !usesLR {
 			// On x86, call instruction pushes return PC before entering new function.
-			frame.varp -= goarch.PtrSize
+			itr.frame.varp -= goarch.PtrSize
 		}
 
 		// For architectures with frame pointers, if there's
@@ -320,11 +319,11 @@ func (itr *tracebackIterator) Gentraceback() int {
 		// This is technically ABI-compatible but not standard.
 		// And it happens to end up mimicking the x86 layout.
 		// Other architectures may make different decisions.
-		if frame.varp > frame.sp && framepointer_enabled {
-			frame.varp -= goarch.PtrSize
+		if itr.frame.varp > itr.frame.sp && framepointer_enabled {
+			itr.frame.varp -= goarch.PtrSize
 		}
 
-		frame.argp = frame.fp + sys.MinFrameSize
+		itr.frame.argp = itr.frame.fp + sys.MinFrameSize
 
 		// Determine frame's 'continuation PC', where it can continue.
 		// Normally this is the return address on the stack, but if sigpanic
@@ -335,10 +334,10 @@ func (itr *tracebackIterator) Gentraceback() int {
 		// defers do not recover) or it returns from one of the calls to
 		// deferproc a second time (if the corresponding deferred func recovers).
 		// In the latter case, use a deferreturn call site as the continuation pc.
-		frame.continpc = frame.pc
+		itr.frame.continpc = itr.frame.pc
 		if itr.waspanic {
-			if frame.fn.deferreturn != 0 {
-				frame.continpc = frame.fn.entry() + uintptr(frame.fn.deferreturn) + 1
+			if itr.frame.fn.deferreturn != 0 {
+				itr.frame.continpc = itr.frame.fn.entry() + uintptr(itr.frame.fn.deferreturn) + 1
 				// Note: this may perhaps keep return variables alive longer than
 				// strictly necessary, as we are using "function has a defer statement"
 				// as a proxy for "function actually deferred something". It seems
@@ -349,18 +348,18 @@ func (itr *tracebackIterator) Gentraceback() int {
 				// stack.go:getStackMap does to back up a return
 				// address make sure the pc is in the CALL instruction.
 			} else {
-				frame.continpc = 0
+				itr.frame.continpc = 0
 			}
 		}
 
 		if itr.callback != nil {
-			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&frame))), noescape(itr.v)) {
+			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
 				return n
 			}
 		}
 
 		if itr.pcbuf != nil {
-			pc := frame.pc
+			pc := itr.frame.pc
 			// backup to CALL instruction to read inlining info (same logic as below)
 			tracepc := pc
 			// Normally, pc is a return address. In that case, we want to look up
@@ -398,7 +397,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					}
 					lastFuncID = inltree[ix].funcID
 					// Back up to an instruction in the "caller".
-					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
+					tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 					pc = tracepc + 1
 				}
 			}
@@ -424,8 +423,8 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// function. Otherwise, leave them out.
 
 			// backup to CALL instruction to read inlining info (same logic as below)
-			tracepc := frame.pc
-			if (n > 0 || itr.flags&_TraceTrap == 0) && frame.pc > f.entry() && !itr.waspanic {
+			tracepc := itr.frame.pc
+			if (n > 0 || itr.flags&_TraceTrap == 0) && itr.frame.pc > f.entry() && !itr.waspanic {
 				tracepc--
 			}
 			// If there is inlining info, print the inner frames.
@@ -454,7 +453,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					}
 					lastFuncID = inltree[ix].funcID
 					// Back up to an instruction in the "caller".
-					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
+					tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 				}
 			}
 			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, itr.nprint == 0, f.funcID, lastFuncID) {
@@ -468,15 +467,15 @@ func (itr *tracebackIterator) Gentraceback() int {
 					name = "panic"
 				}
 				print(name, "(")
-				argp := unsafe.Pointer(frame.argp)
+				argp := unsafe.Pointer(itr.frame.argp)
 				printArgs(f, argp, tracepc)
 				print(")\n")
 				print("\t", file, ":", line)
-				if frame.pc > f.entry() {
-					print(" +", hex(frame.pc-f.entry()))
+				if itr.frame.pc > f.entry() {
+					print(" +", hex(itr.frame.pc-f.entry()))
 				}
 				if itr.gp.m != nil && itr.gp.m.throwing >= throwTypeRuntime && itr.gp == itr.gp.m.curg || itr.level >= 2 {
-					print(" fp=", hex(frame.fp), " sp=", hex(frame.sp), " pc=", hex(frame.pc))
+					print(" fp=", hex(itr.frame.fp), " sp=", hex(itr.frame.sp), " pc=", hex(itr.frame.pc))
 				}
 				print("\n")
 				itr.nprint++
@@ -505,31 +504,31 @@ func (itr *tracebackIterator) Gentraceback() int {
 			break
 		}
 
-		if frame.pc == frame.lr && frame.sp == frame.fp {
+		if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
 			// If the next frame is identical to the current frame, we cannot make progress.
-			print("runtime: traceback stuck. pc=", hex(frame.pc), " sp=", hex(frame.sp), "\n")
-			tracebackHexdump(itr.stack, &frame, frame.sp)
+			print("runtime: traceback stuck. pc=", hex(itr.frame.pc), " sp=", hex(itr.frame.sp), "\n")
+			tracebackHexdump(itr.stack, &itr.frame, itr.frame.sp)
 			throw("traceback stuck")
 		}
 
 		// Unwind to next frame.
-		frame.fn = flr
-		frame.pc = frame.lr
-		frame.lr = 0
-		frame.sp = frame.fp
-		frame.fp = 0
+		setFuncInfoNoWB(&itr.frame.fn, flr)
+		itr.frame.pc = itr.frame.lr
+		itr.frame.lr = 0
+		itr.frame.sp = itr.frame.fp
+		itr.frame.fp = 0
 
 		// On link register architectures, sighandler saves the LR on stack
 		// before faking a call.
 		if usesLR && injectedCall {
-			x := *(*uintptr)(unsafe.Pointer(frame.sp))
-			frame.sp += alignUp(sys.MinFrameSize, sys.StackAlign)
-			f = findfunc(frame.pc)
-			frame.fn = f
+			x := *(*uintptr)(unsafe.Pointer(itr.frame.sp))
+			itr.frame.sp += alignUp(sys.MinFrameSize, sys.StackAlign)
+			f = findfunc(itr.frame.pc)
+			setFuncInfoNoWB(&itr.frame.fn, f)
 			if !f.valid() {
-				frame.pc = x
-			} else if funcspdelta(f, frame.pc, &cache) == 0 {
-				frame.lr = x
+				itr.frame.pc = x
+			} else if funcspdelta(f, itr.frame.pc, &cache) == 0 {
+				itr.frame.lr = x
 			}
 		}
 	}
@@ -578,8 +577,8 @@ func (itr *tracebackIterator) Gentraceback() int {
 	// At other times, such as when gathering a stack for a profiling signal
 	// or when printing a traceback during a crash, everything may not be
 	// stopped nicely, and the stack walk may not be able to complete.
-	if itr.callback != nil && n < itr.max && frame.sp != itr.gp.stktopsp {
-		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
+	if itr.callback != nil && n < itr.max && itr.frame.sp != itr.gp.stktopsp {
+		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(itr.frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
 		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", n, " max=", itr.max, "\n")
 		throw("traceback did not unwind completely")
 	}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -39,14 +39,15 @@ type tracebackIterator struct {
 	v             unsafe.Pointer
 	flags         uint
 
-	level    int32
-	nprint   int
-	frame    stkframe
-	waspanic bool
-	cgoCtxt  []uintptr
-	stack    stack
-	printing bool
-	cache    pcvalueCache
+	level      int32
+	nprint     int
+	frame      stkframe
+	waspanic   bool
+	cgoCtxt    []uintptr
+	stack      stack
+	printing   bool
+	cache      pcvalueCache
+	lastFuncID funcID
 }
 
 func (itr *tracebackIterator) init() bool {
@@ -139,13 +140,14 @@ func (itr *tracebackIterator) init() bool {
 		return false
 	}
 	setFuncInfoNoWB(&itr.frame.fn, f)
+
+	itr.lastFuncID = funcID_normal
+
 	return true
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
 	f := itr.frame.fn
-
-	lastFuncID := funcID_normal
 	n := 0
 	for n < itr.max {
 		// Typically:
@@ -386,7 +388,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					if ix < 0 {
 						break
 					}
-					if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(lastFuncID) {
+					if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
 						// ignore wrappers
 					} else if itr.skip > 0 {
 						itr.skip--
@@ -394,14 +396,14 @@ func (itr *tracebackIterator) Gentraceback() int {
 						(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
 						n++
 					}
-					lastFuncID = inltree[ix].funcID
+					itr.lastFuncID = inltree[ix].funcID
 					// Back up to an instruction in the "caller".
 					tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 					pc = tracepc + 1
 				}
 			}
 			// Record the main frame.
-			if f.funcID == funcID_wrapper && elideWrapperCalling(lastFuncID) {
+			if f.funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
 				// Ignore wrapper functions (except when they trigger panics).
 			} else if itr.skip > 0 {
 				itr.skip--
@@ -409,7 +411,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 				(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
 				n++
 			}
-			lastFuncID = f.funcID
+			itr.lastFuncID = f.funcID
 			n-- // offset n++ below
 		}
 
@@ -443,19 +445,19 @@ func (itr *tracebackIterator) Gentraceback() int {
 					inlFunc.funcID = inltree[ix].funcID
 					inlFunc.startLine = inltree[ix].startLine
 
-					if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, itr.nprint == 0, inlFuncInfo.funcID, lastFuncID) {
+					if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, itr.nprint == 0, inlFuncInfo.funcID, itr.lastFuncID) {
 						name := funcname(inlFuncInfo)
 						file, line := funcline(f, tracepc)
 						print(name, "(...)\n")
 						print("\t", file, ":", line, "\n")
 						itr.nprint++
 					}
-					lastFuncID = inltree[ix].funcID
+					itr.lastFuncID = inltree[ix].funcID
 					// Back up to an instruction in the "caller".
 					tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 				}
 			}
-			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, itr.nprint == 0, f.funcID, lastFuncID) {
+			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, itr.nprint == 0, f.funcID, itr.lastFuncID) {
 				// Print during crash.
 				//	main(0x1, 0x2, 0x3)
 				//		/home/rsc/go/src/runtime/x.go:23 +0xf
@@ -479,7 +481,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 				print("\n")
 				itr.nprint++
 			}
-			lastFuncID = f.funcID
+			itr.lastFuncID = f.funcID
 		}
 		n++
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -14,7 +14,7 @@ type tracebackState int
 
 const (
 	stateInit tracebackState = iota
-	statePrepareFrame
+	statePreambleFrame
 	stateBufInlineFrame
 	stateBufNormalFrame
 	statePostamble
@@ -263,14 +263,14 @@ yield:
 		case stateInit:
 			switch itr.event = itr.init(); itr.event {
 			case eventOK:
-				itr.state = statePrepareFrame
+				itr.state = statePreambleFrame
 			default:
 				itr.state = stateError
 				break yield
 			}
 
-		case statePrepareFrame:
-			switch itr.event = itr.prepareFrame(); itr.event {
+		case statePreambleFrame:
+			switch itr.event = itr.preamble(); itr.event {
 			case eventPCBufInline:
 				itr.state = stateBufInlineFrame
 			case eventBufNormal:
@@ -307,9 +307,9 @@ yield:
 			}
 
 		case statePostamble:
-			switch itr.event = itr.next(); itr.event {
+			switch itr.event = itr.postamble(); itr.event {
 			case eventOK:
-				itr.state = statePrepareFrame
+				itr.state = statePreambleFrame
 				more = true
 				break yield
 			case eventBottomOfStack, eventMaxReached:
@@ -328,7 +328,7 @@ yield:
 	return more
 }
 
-func (itr *tracebackIterator) prepareFrame() tracebackEvent {
+func (itr *tracebackIterator) preamble() tracebackEvent {
 	if itr.n >= itr.max {
 		return eventMaxReached
 	}
@@ -621,7 +621,7 @@ func (itr *tracebackIterator) normalFrame() tracebackEvent {
 	return eventOK
 }
 
-func (itr *tracebackIterator) next() tracebackEvent {
+func (itr *tracebackIterator) postamble() tracebackEvent {
 	f := itr.frame.fn
 	if itr.printing {
 		// assume skip=0 for printing.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -26,7 +26,10 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	if !itr.init() {
 		return 0
 	}
-	itr.Gentraceback()
+
+	for itr.Next() {
+	}
+
 	if itr.callbackAbort {
 		return itr.n
 	}
@@ -203,393 +206,396 @@ func (itr *tracebackIterator) init() bool {
 	return true
 }
 
-func (itr *tracebackIterator) Gentraceback() {
+func (itr *tracebackIterator) Next() bool {
+	if itr.n >= itr.max {
+		return false
+	}
+
 	f := itr.frame.fn
-	for itr.n < itr.max {
-		// Typically:
-		//	pc is the PC of the running function.
-		//	sp is the stack pointer at that program counter.
-		//	fp is the frame pointer (caller's stack pointer) at that program counter, or nil if unknown.
-		//	stk is the stack containing sp.
-		//	The caller's program counter is lr, unless lr is zero, in which case it is *(uintptr*)sp.
-		f = itr.frame.fn
-		if f.pcsp == 0 {
-			// No frame information, must be external function, like race support.
-			// See golang.org/issue/13568.
-			break
-		}
+	// Typically:
+	//	pc is the PC of the running function.
+	//	sp is the stack pointer at that program counter.
+	//	fp is the frame pointer (caller's stack pointer) at that program counter, or nil if unknown.
+	//	stk is the stack containing sp.
+	//	The caller's program counter is lr, unless lr is zero, in which case it is *(uintptr*)sp.
+	f = itr.frame.fn
+	if f.pcsp == 0 {
+		// No frame information, must be external function, like race support.
+		// See golang.org/issue/13568.
+		return false
+	}
 
-		// Compute function info flags.
-		flag := f.flag
-		if f.funcID == funcID_cgocallback {
-			// cgocallback does write SP to switch from the g0 to the curg stack,
-			// but it carefully arranges that during the transition BOTH stacks
-			// have cgocallback frame valid for unwinding through.
-			// So we don't need to exclude it with the other SP-writing functions.
-			flag &^= funcFlag_SPWRITE
-		}
-		if itr.frame.pc == itr.pc0 && itr.frame.sp == itr.sp0 && itr.pc0 == itr.gp.syscallpc && itr.sp0 == itr.gp.syscallsp {
-			// Some Syscall functions write to SP, but they do so only after
-			// saving the entry PC/SP using entersyscall.
-			// Since we are using the entry PC/SP, the later SP write doesn't matter.
-			flag &^= funcFlag_SPWRITE
-		}
+	// Compute function info flags.
+	flag := f.flag
+	if f.funcID == funcID_cgocallback {
+		// cgocallback does write SP to switch from the g0 to the curg stack,
+		// but it carefully arranges that during the transition BOTH stacks
+		// have cgocallback frame valid for unwinding through.
+		// So we don't need to exclude it with the other SP-writing functions.
+		flag &^= funcFlag_SPWRITE
+	}
+	if itr.frame.pc == itr.pc0 && itr.frame.sp == itr.sp0 && itr.pc0 == itr.gp.syscallpc && itr.sp0 == itr.gp.syscallsp {
+		// Some Syscall functions write to SP, but they do so only after
+		// saving the entry PC/SP using entersyscall.
+		// Since we are using the entry PC/SP, the later SP write doesn't matter.
+		flag &^= funcFlag_SPWRITE
+	}
 
-		// Found an actual function.
-		// Derive frame pointer and link register.
-		if itr.frame.fp == 0 {
-			// Jump over system stack transitions. If we're on g0 and there's a user
-			// goroutine, try to jump. Otherwise this is a regular call.
-			// We also defensively check that this won't switch M's on us,
-			// which could happen at critical points in the scheduler.
-			// This ensures gp.m doesn't change from a stack jump.
-			if itr.flags&_TraceJumpStack != 0 && itr.gp == itr.gp.m.g0 && itr.gp.m.curg != nil && itr.gp.m.curg.m == itr.gp.m {
-				switch f.funcID {
-				case funcID_morestack:
-					// morestack does not return normally -- newstack()
-					// gogo's to curg.sched. Match that.
-					// This keeps morestack() from showing up in the backtrace,
-					// but that makes some sense since it'll never be returned
-					// to.
-					setGNoWB(&itr.gp, itr.gp.m.curg)
-					itr.frame.pc = itr.gp.sched.pc
-					setFuncInfoNoWB(&itr.frame.fn, findfunc(itr.frame.pc))
-					f = itr.frame.fn
-					flag = f.flag
-					itr.frame.lr = itr.gp.sched.lr
-					itr.frame.sp = itr.gp.sched.sp
-					itr.stack = itr.gp.stack
-					setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
-				case funcID_systemstack:
-					// systemstack returns normally, so just follow the
-					// stack transition.
-					if usesLR && funcspdelta(f, itr.frame.pc, &itr.cache) == 0 {
-						// We're at the function prologue and the stack
-						// switch hasn't happened, or epilogue where we're
-						// about to return. Just unwind normally.
-						// Do this only on LR machines because on x86
-						// systemstack doesn't have an SP delta (the CALL
-						// instruction opens the frame), therefore no way
-						// to check.
-						flag &^= funcFlag_SPWRITE
-						break
-					}
-					setGNoWB(&itr.gp, itr.gp.m.curg)
-					itr.frame.sp = itr.gp.sched.sp
-					itr.stack = itr.gp.stack
-					setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+	// Found an actual function.
+	// Derive frame pointer and link register.
+	if itr.frame.fp == 0 {
+		// Jump over system stack transitions. If we're on g0 and there's a user
+		// goroutine, try to jump. Otherwise this is a regular call.
+		// We also defensively check that this won't switch M's on us,
+		// which could happen at critical points in the scheduler.
+		// This ensures gp.m doesn't change from a stack jump.
+		if itr.flags&_TraceJumpStack != 0 && itr.gp == itr.gp.m.g0 && itr.gp.m.curg != nil && itr.gp.m.curg.m == itr.gp.m {
+			switch f.funcID {
+			case funcID_morestack:
+				// morestack does not return normally -- newstack()
+				// gogo's to curg.sched. Match that.
+				// This keeps morestack() from showing up in the backtrace,
+				// but that makes some sense since it'll never be returned
+				// to.
+				setGNoWB(&itr.gp, itr.gp.m.curg)
+				itr.frame.pc = itr.gp.sched.pc
+				setFuncInfoNoWB(&itr.frame.fn, findfunc(itr.frame.pc))
+				f = itr.frame.fn
+				flag = f.flag
+				itr.frame.lr = itr.gp.sched.lr
+				itr.frame.sp = itr.gp.sched.sp
+				itr.stack = itr.gp.stack
+				setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+			case funcID_systemstack:
+				// systemstack returns normally, so just follow the
+				// stack transition.
+				if usesLR && funcspdelta(f, itr.frame.pc, &itr.cache) == 0 {
+					// We're at the function prologue and the stack
+					// switch hasn't happened, or epilogue where we're
+					// about to return. Just unwind normally.
+					// Do this only on LR machines because on x86
+					// systemstack doesn't have an SP delta (the CALL
+					// instruction opens the frame), therefore no way
+					// to check.
 					flag &^= funcFlag_SPWRITE
+					return false
 				}
-			}
-			itr.frame.fp = itr.frame.sp + uintptr(funcspdelta(f, itr.frame.pc, &itr.cache))
-			if !usesLR {
-				// On x86, call instruction pushes return PC before entering new function.
-				itr.frame.fp += goarch.PtrSize
-			}
-		}
-		var flr funcInfo
-		if flag&funcFlag_TOPFRAME != 0 {
-			// This function marks the top of the stack. Stop the traceback.
-			itr.frame.lr = 0
-			flr = funcInfo{}
-		} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || itr.n > 0) {
-			// The function we are in does a write to SP that we don't know
-			// how to encode in the spdelta table. Examples include context
-			// switch routines like runtime.gogo but also any code that switches
-			// to the g0 stack to run host C code. Since we can't reliably unwind
-			// the SP (we might not even be on the stack we think we are),
-			// we stop the traceback here.
-			// This only applies for profiling signals (callback == nil).
-			//
-			// For a GC stack traversal (callback != nil), we should only see
-			// a function when it has voluntarily preempted itself on entry
-			// during the stack growth check. In that case, the function has
-			// not yet had a chance to do any writes to SP and is safe to unwind.
-			// isAsyncSafePoint does not allow assembly functions to be async preempted,
-			// and preemptPark double-checks that SPWRITE functions are not async preempted.
-			// So for GC stack traversal we leave things alone (this if body does not execute for n == 0)
-			// at the bottom frame of the stack. But farther up the stack we'd better not
-			// find any.
-			if itr.callback != nil {
-				println("traceback: unexpected SPWRITE function", funcname(f))
-				throw("traceback")
-			}
-			itr.frame.lr = 0
-			flr = funcInfo{}
-		} else {
-			var lrPtr uintptr
-			if usesLR {
-				if itr.n == 0 && itr.frame.sp < itr.frame.fp || itr.frame.lr == 0 {
-					lrPtr = itr.frame.sp
-					itr.frame.lr = *(*uintptr)(unsafe.Pointer(lrPtr))
-				}
-			} else {
-				if itr.frame.lr == 0 {
-					lrPtr = itr.frame.fp - goarch.PtrSize
-					itr.frame.lr = uintptr(*(*uintptr)(unsafe.Pointer(lrPtr)))
-				}
-			}
-			flr = findfunc(itr.frame.lr)
-			if !flr.valid() {
-				// This happens if you get a profiling interrupt at just the wrong time.
-				// In that context it is okay to stop early.
-				// But if callback is set, we're doing a garbage collection and must
-				// get everything, so crash loudly.
-				doPrint := itr.printing
-				if doPrint && itr.gp.m.incgo && f.funcID == funcID_sigpanic {
-					// We can inject sigpanic
-					// calls directly into C code,
-					// in which case we'll see a C
-					// return PC. Don't complain.
-					doPrint = false
-				}
-				if itr.callback != nil || doPrint {
-					print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(itr.frame.lr), "\n")
-					tracebackHexdump(itr.stack, &itr.frame, lrPtr)
-				}
-				if itr.callback != nil {
-					throw("unknown caller pc")
-				}
+				setGNoWB(&itr.gp, itr.gp.m.curg)
+				itr.frame.sp = itr.gp.sched.sp
+				itr.stack = itr.gp.stack
+				setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+				flag &^= funcFlag_SPWRITE
 			}
 		}
-
-		itr.frame.varp = itr.frame.fp
+		itr.frame.fp = itr.frame.sp + uintptr(funcspdelta(f, itr.frame.pc, &itr.cache))
 		if !usesLR {
 			// On x86, call instruction pushes return PC before entering new function.
-			itr.frame.varp -= goarch.PtrSize
+			itr.frame.fp += goarch.PtrSize
 		}
-
-		// For architectures with frame pointers, if there's
-		// a frame, then there's a saved frame pointer here.
-		//
-		// NOTE: This code is not as general as it looks.
-		// On x86, the ABI is to save the frame pointer word at the
-		// top of the stack frame, so we have to back down over it.
-		// On arm64, the frame pointer should be at the bottom of
-		// the stack (with R29 (aka FP) = RSP), in which case we would
-		// not want to do the subtraction here. But we started out without
-		// any frame pointer, and when we wanted to add it, we didn't
-		// want to break all the assembly doing direct writes to 8(RSP)
-		// to set the first parameter to a called function.
-		// So we decided to write the FP link *below* the stack pointer
-		// (with R29 = RSP - 8 in Go functions).
-		// This is technically ABI-compatible but not standard.
-		// And it happens to end up mimicking the x86 layout.
-		// Other architectures may make different decisions.
-		if itr.frame.varp > itr.frame.sp && framepointer_enabled {
-			itr.frame.varp -= goarch.PtrSize
-		}
-
-		itr.frame.argp = itr.frame.fp + sys.MinFrameSize
-
-		// Determine frame's 'continuation PC', where it can continue.
-		// Normally this is the return address on the stack, but if sigpanic
-		// is immediately below this function on the stack, then the frame
-		// stopped executing due to a trap, and frame.pc is probably not
-		// a safe point for looking up liveness information. In this panicking case,
-		// the function either doesn't return at all (if it has no defers or if the
-		// defers do not recover) or it returns from one of the calls to
-		// deferproc a second time (if the corresponding deferred func recovers).
-		// In the latter case, use a deferreturn call site as the continuation pc.
-		itr.frame.continpc = itr.frame.pc
-		if itr.waspanic {
-			if itr.frame.fn.deferreturn != 0 {
-				itr.frame.continpc = itr.frame.fn.entry() + uintptr(itr.frame.fn.deferreturn) + 1
-				// Note: this may perhaps keep return variables alive longer than
-				// strictly necessary, as we are using "function has a defer statement"
-				// as a proxy for "function actually deferred something". It seems
-				// to be a minor drawback. (We used to actually look through the
-				// gp._defer for a defer corresponding to this function, but that
-				// is hard to do with defer records on the stack during a stack copy.)
-				// Note: the +1 is to offset the -1 that
-				// stack.go:getStackMap does to back up a return
-				// address make sure the pc is in the CALL instruction.
-			} else {
-				itr.frame.continpc = 0
-			}
-		}
-
-		if itr.callback != nil {
-			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
-				itr.callbackAbort = true
-				return
-			}
-		}
-
-		if itr.pcbuf != nil {
-			pc := itr.frame.pc
-			// backup to CALL instruction to read inlining info (same logic as below)
-			tracepc := pc
-			// Normally, pc is a return address. In that case, we want to look up
-			// file/line information using pc-1, because that is the pc of the
-			// call instruction (more precisely, the last byte of the call instruction).
-			// Callers expect the pc buffer to contain return addresses and do the
-			// same -1 themselves, so we keep pc unchanged.
-			// When the pc is from a signal (e.g. profiler or segv) then we want
-			// to look up file/line information using pc, and we store pc+1 in the
-			// pc buffer so callers can unconditionally subtract 1 before looking up.
-			// See issue 34123.
-			// The pc can be at function entry when the frame is initialized without
-			// actually running code, like runtime.mstart.
-			if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || pc == f.entry() {
-				pc++
-			} else {
-				tracepc--
-			}
-
-			// If there is inlining info, record the inner frames.
-			if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
-				inltree := (*[1 << 20]inlinedCall)(inldata)
-				for {
-					ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, &itr.cache)
-					if ix < 0 {
-						break
-					}
-					if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
-						// ignore wrappers
-					} else if itr.skip > 0 {
-						itr.skip--
-					} else if itr.n < itr.max {
-						(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
-						itr.n++
-					}
-					itr.lastFuncID = inltree[ix].funcID
-					// Back up to an instruction in the "caller".
-					tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
-					pc = tracepc + 1
-				}
-			}
-			// Record the main frame.
-			if f.funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
-				// Ignore wrapper functions (except when they trigger panics).
-			} else if itr.skip > 0 {
-				itr.skip--
-			} else if itr.n < itr.max {
-				(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
-				itr.n++
-			}
-			itr.lastFuncID = f.funcID
-			itr.n-- // offset n++ below
-		}
-
-		if itr.printing {
-			// assume skip=0 for printing.
-			//
-			// Never elide wrappers if we haven't printed
-			// any frames. And don't elide wrappers that
-			// called panic rather than the wrapped
-			// function. Otherwise, leave them out.
-
-			// backup to CALL instruction to read inlining info (same logic as below)
-			tracepc := itr.frame.pc
-			if (itr.n > 0 || itr.flags&_TraceTrap == 0) && itr.frame.pc > f.entry() && !itr.waspanic {
-				tracepc--
-			}
-			// If there is inlining info, print the inner frames.
-			if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
-				inltree := (*[1 << 20]inlinedCall)(inldata)
-				var inlFunc _func
-				inlFuncInfo := funcInfo{&inlFunc, f.datap}
-				for {
-					ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, nil)
-					if ix < 0 {
-						break
-					}
-
-					// Create a fake _func for the
-					// inlined function.
-					inlFunc.nameOff = inltree[ix].nameOff
-					inlFunc.funcID = inltree[ix].funcID
-					inlFunc.startLine = inltree[ix].startLine
-
-					if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, itr.nprint == 0, inlFuncInfo.funcID, itr.lastFuncID) {
-						name := funcname(inlFuncInfo)
-						file, line := funcline(f, tracepc)
-						print(name, "(...)\n")
-						print("\t", file, ":", line, "\n")
-						itr.nprint++
-					}
-					itr.lastFuncID = inltree[ix].funcID
-					// Back up to an instruction in the "caller".
-					tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
-				}
-			}
-			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, itr.nprint == 0, f.funcID, itr.lastFuncID) {
-				// Print during crash.
-				//	main(0x1, 0x2, 0x3)
-				//		/home/rsc/go/src/runtime/x.go:23 +0xf
-				//
-				name := funcname(f)
-				file, line := funcline(f, tracepc)
-				if name == "runtime.gopanic" {
-					name = "panic"
-				}
-				print(name, "(")
-				argp := unsafe.Pointer(itr.frame.argp)
-				printArgs(f, argp, tracepc)
-				print(")\n")
-				print("\t", file, ":", line)
-				if itr.frame.pc > f.entry() {
-					print(" +", hex(itr.frame.pc-f.entry()))
-				}
-				if itr.gp.m != nil && itr.gp.m.throwing >= throwTypeRuntime && itr.gp == itr.gp.m.curg || itr.level >= 2 {
-					print(" fp=", hex(itr.frame.fp), " sp=", hex(itr.frame.sp), " pc=", hex(itr.frame.pc))
-				}
-				print("\n")
-				itr.nprint++
-			}
-			itr.lastFuncID = f.funcID
-		}
-		itr.n++
-
-		if f.funcID == funcID_cgocallback && len(itr.cgoCtxt) > 0 {
-			ctxt := itr.cgoCtxt[len(itr.cgoCtxt)-1]
-			itr.cgoCtxt = itr.cgoCtxt[:len(itr.cgoCtxt)-1]
-
-			// skip only applies to Go frames.
-			// callback != nil only used when we only care
-			// about Go frames.
-			if itr.skip == 0 && itr.callback == nil {
-				itr.n = tracebackCgoContext(itr.pcbuf, itr.printing, ctxt, itr.n, itr.max)
-			}
-		}
-
-		itr.waspanic = f.funcID == funcID_sigpanic
-		injectedCall := itr.waspanic || f.funcID == funcID_asyncPreempt || f.funcID == funcID_debugCallV2
-
-		// Do not unwind past the bottom of the stack.
-		if !flr.valid() {
-			break
-		}
-
-		if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
-			// If the next frame is identical to the current frame, we cannot make progress.
-			print("runtime: traceback stuck. pc=", hex(itr.frame.pc), " sp=", hex(itr.frame.sp), "\n")
-			tracebackHexdump(itr.stack, &itr.frame, itr.frame.sp)
-			throw("traceback stuck")
-		}
-
-		// Unwind to next frame.
-		setFuncInfoNoWB(&itr.frame.fn, flr)
-		itr.frame.pc = itr.frame.lr
+	}
+	var flr funcInfo
+	if flag&funcFlag_TOPFRAME != 0 {
+		// This function marks the top of the stack. Stop the traceback.
 		itr.frame.lr = 0
-		itr.frame.sp = itr.frame.fp
-		itr.frame.fp = 0
-
-		// On link register architectures, sighandler saves the LR on stack
-		// before faking a call.
-		if usesLR && injectedCall {
-			x := *(*uintptr)(unsafe.Pointer(itr.frame.sp))
-			itr.frame.sp += alignUp(sys.MinFrameSize, sys.StackAlign)
-			f = findfunc(itr.frame.pc)
-			setFuncInfoNoWB(&itr.frame.fn, f)
-			if !f.valid() {
-				itr.frame.pc = x
-			} else if funcspdelta(f, itr.frame.pc, &itr.cache) == 0 {
-				itr.frame.lr = x
+		flr = funcInfo{}
+	} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || itr.n > 0) {
+		// The function we are in does a write to SP that we don't know
+		// how to encode in the spdelta table. Examples include context
+		// switch routines like runtime.gogo but also any code that switches
+		// to the g0 stack to run host C code. Since we can't reliably unwind
+		// the SP (we might not even be on the stack we think we are),
+		// we stop the traceback here.
+		// This only applies for profiling signals (callback == nil).
+		//
+		// For a GC stack traversal (callback != nil), we should only see
+		// a function when it has voluntarily preempted itself on entry
+		// during the stack growth check. In that case, the function has
+		// not yet had a chance to do any writes to SP and is safe to unwind.
+		// isAsyncSafePoint does not allow assembly functions to be async preempted,
+		// and preemptPark double-checks that SPWRITE functions are not async preempted.
+		// So for GC stack traversal we leave things alone (this if body does not execute for n == 0)
+		// at the bottom frame of the stack. But farther up the stack we'd better not
+		// find any.
+		if itr.callback != nil {
+			println("traceback: unexpected SPWRITE function", funcname(f))
+			throw("traceback")
+		}
+		itr.frame.lr = 0
+		flr = funcInfo{}
+	} else {
+		var lrPtr uintptr
+		if usesLR {
+			if itr.n == 0 && itr.frame.sp < itr.frame.fp || itr.frame.lr == 0 {
+				lrPtr = itr.frame.sp
+				itr.frame.lr = *(*uintptr)(unsafe.Pointer(lrPtr))
+			}
+		} else {
+			if itr.frame.lr == 0 {
+				lrPtr = itr.frame.fp - goarch.PtrSize
+				itr.frame.lr = uintptr(*(*uintptr)(unsafe.Pointer(lrPtr)))
+			}
+		}
+		flr = findfunc(itr.frame.lr)
+		if !flr.valid() {
+			// This happens if you get a profiling interrupt at just the wrong time.
+			// In that context it is okay to stop early.
+			// But if callback is set, we're doing a garbage collection and must
+			// get everything, so crash loudly.
+			doPrint := itr.printing
+			if doPrint && itr.gp.m.incgo && f.funcID == funcID_sigpanic {
+				// We can inject sigpanic
+				// calls directly into C code,
+				// in which case we'll see a C
+				// return PC. Don't complain.
+				doPrint = false
+			}
+			if itr.callback != nil || doPrint {
+				print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(itr.frame.lr), "\n")
+				tracebackHexdump(itr.stack, &itr.frame, lrPtr)
+			}
+			if itr.callback != nil {
+				throw("unknown caller pc")
 			}
 		}
 	}
+
+	itr.frame.varp = itr.frame.fp
+	if !usesLR {
+		// On x86, call instruction pushes return PC before entering new function.
+		itr.frame.varp -= goarch.PtrSize
+	}
+
+	// For architectures with frame pointers, if there's
+	// a frame, then there's a saved frame pointer here.
+	//
+	// NOTE: This code is not as general as it looks.
+	// On x86, the ABI is to save the frame pointer word at the
+	// top of the stack frame, so we have to back down over it.
+	// On arm64, the frame pointer should be at the bottom of
+	// the stack (with R29 (aka FP) = RSP), in which case we would
+	// not want to do the subtraction here. But we started out without
+	// any frame pointer, and when we wanted to add it, we didn't
+	// want to break all the assembly doing direct writes to 8(RSP)
+	// to set the first parameter to a called function.
+	// So we decided to write the FP link *below* the stack pointer
+	// (with R29 = RSP - 8 in Go functions).
+	// This is technically ABI-compatible but not standard.
+	// And it happens to end up mimicking the x86 layout.
+	// Other architectures may make different decisions.
+	if itr.frame.varp > itr.frame.sp && framepointer_enabled {
+		itr.frame.varp -= goarch.PtrSize
+	}
+
+	itr.frame.argp = itr.frame.fp + sys.MinFrameSize
+
+	// Determine frame's 'continuation PC', where it can continue.
+	// Normally this is the return address on the stack, but if sigpanic
+	// is immediately below this function on the stack, then the frame
+	// stopped executing due to a trap, and frame.pc is probably not
+	// a safe point for looking up liveness information. In this panicking case,
+	// the function either doesn't return at all (if it has no defers or if the
+	// defers do not recover) or it returns from one of the calls to
+	// deferproc a second time (if the corresponding deferred func recovers).
+	// In the latter case, use a deferreturn call site as the continuation pc.
+	itr.frame.continpc = itr.frame.pc
+	if itr.waspanic {
+		if itr.frame.fn.deferreturn != 0 {
+			itr.frame.continpc = itr.frame.fn.entry() + uintptr(itr.frame.fn.deferreturn) + 1
+			// Note: this may perhaps keep return variables alive longer than
+			// strictly necessary, as we are using "function has a defer statement"
+			// as a proxy for "function actually deferred something". It seems
+			// to be a minor drawback. (We used to actually look through the
+			// gp._defer for a defer corresponding to this function, but that
+			// is hard to do with defer records on the stack during a stack copy.)
+			// Note: the +1 is to offset the -1 that
+			// stack.go:getStackMap does to back up a return
+			// address make sure the pc is in the CALL instruction.
+		} else {
+			itr.frame.continpc = 0
+		}
+	}
+
+	if itr.callback != nil {
+		if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
+			itr.callbackAbort = true
+			return false
+		}
+	}
+
+	if itr.pcbuf != nil {
+		pc := itr.frame.pc
+		// backup to CALL instruction to read inlining info (same logic as below)
+		tracepc := pc
+		// Normally, pc is a return address. In that case, we want to look up
+		// file/line information using pc-1, because that is the pc of the
+		// call instruction (more precisely, the last byte of the call instruction).
+		// Callers expect the pc buffer to contain return addresses and do the
+		// same -1 themselves, so we keep pc unchanged.
+		// When the pc is from a signal (e.g. profiler or segv) then we want
+		// to look up file/line information using pc, and we store pc+1 in the
+		// pc buffer so callers can unconditionally subtract 1 before looking up.
+		// See issue 34123.
+		// The pc can be at function entry when the frame is initialized without
+		// actually running code, like runtime.mstart.
+		if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || pc == f.entry() {
+			pc++
+		} else {
+			tracepc--
+		}
+
+		// If there is inlining info, record the inner frames.
+		if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
+			inltree := (*[1 << 20]inlinedCall)(inldata)
+			for {
+				ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, &itr.cache)
+				if ix < 0 {
+					break
+				}
+				if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
+					// ignore wrappers
+				} else if itr.skip > 0 {
+					itr.skip--
+				} else if itr.n < itr.max {
+					(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
+					itr.n++
+				}
+				itr.lastFuncID = inltree[ix].funcID
+				// Back up to an instruction in the "caller".
+				tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
+				pc = tracepc + 1
+			}
+		}
+		// Record the main frame.
+		if f.funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
+			// Ignore wrapper functions (except when they trigger panics).
+		} else if itr.skip > 0 {
+			itr.skip--
+		} else if itr.n < itr.max {
+			(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
+			itr.n++
+		}
+		itr.lastFuncID = f.funcID
+		itr.n-- // offset n++ below
+	}
+
+	if itr.printing {
+		// assume skip=0 for printing.
+		//
+		// Never elide wrappers if we haven't printed
+		// any frames. And don't elide wrappers that
+		// called panic rather than the wrapped
+		// function. Otherwise, leave them out.
+
+		// backup to CALL instruction to read inlining info (same logic as below)
+		tracepc := itr.frame.pc
+		if (itr.n > 0 || itr.flags&_TraceTrap == 0) && itr.frame.pc > f.entry() && !itr.waspanic {
+			tracepc--
+		}
+		// If there is inlining info, print the inner frames.
+		if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
+			inltree := (*[1 << 20]inlinedCall)(inldata)
+			var inlFunc _func
+			inlFuncInfo := funcInfo{&inlFunc, f.datap}
+			for {
+				ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, nil)
+				if ix < 0 {
+					break
+				}
+
+				// Create a fake _func for the
+				// inlined function.
+				inlFunc.nameOff = inltree[ix].nameOff
+				inlFunc.funcID = inltree[ix].funcID
+				inlFunc.startLine = inltree[ix].startLine
+
+				if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, itr.nprint == 0, inlFuncInfo.funcID, itr.lastFuncID) {
+					name := funcname(inlFuncInfo)
+					file, line := funcline(f, tracepc)
+					print(name, "(...)\n")
+					print("\t", file, ":", line, "\n")
+					itr.nprint++
+				}
+				itr.lastFuncID = inltree[ix].funcID
+				// Back up to an instruction in the "caller".
+				tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
+			}
+		}
+		if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, itr.nprint == 0, f.funcID, itr.lastFuncID) {
+			// Print during crash.
+			//	main(0x1, 0x2, 0x3)
+			//		/home/rsc/go/src/runtime/x.go:23 +0xf
+			//
+			name := funcname(f)
+			file, line := funcline(f, tracepc)
+			if name == "runtime.gopanic" {
+				name = "panic"
+			}
+			print(name, "(")
+			argp := unsafe.Pointer(itr.frame.argp)
+			printArgs(f, argp, tracepc)
+			print(")\n")
+			print("\t", file, ":", line)
+			if itr.frame.pc > f.entry() {
+				print(" +", hex(itr.frame.pc-f.entry()))
+			}
+			if itr.gp.m != nil && itr.gp.m.throwing >= throwTypeRuntime && itr.gp == itr.gp.m.curg || itr.level >= 2 {
+				print(" fp=", hex(itr.frame.fp), " sp=", hex(itr.frame.sp), " pc=", hex(itr.frame.pc))
+			}
+			print("\n")
+			itr.nprint++
+		}
+		itr.lastFuncID = f.funcID
+	}
+	itr.n++
+
+	if f.funcID == funcID_cgocallback && len(itr.cgoCtxt) > 0 {
+		ctxt := itr.cgoCtxt[len(itr.cgoCtxt)-1]
+		itr.cgoCtxt = itr.cgoCtxt[:len(itr.cgoCtxt)-1]
+
+		// skip only applies to Go frames.
+		// callback != nil only used when we only care
+		// about Go frames.
+		if itr.skip == 0 && itr.callback == nil {
+			itr.n = tracebackCgoContext(itr.pcbuf, itr.printing, ctxt, itr.n, itr.max)
+		}
+	}
+
+	itr.waspanic = f.funcID == funcID_sigpanic
+	injectedCall := itr.waspanic || f.funcID == funcID_asyncPreempt || f.funcID == funcID_debugCallV2
+
+	// Do not unwind past the bottom of the stack.
+	if !flr.valid() {
+		return false
+	}
+
+	if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
+		// If the next frame is identical to the current frame, we cannot make progress.
+		print("runtime: traceback stuck. pc=", hex(itr.frame.pc), " sp=", hex(itr.frame.sp), "\n")
+		tracebackHexdump(itr.stack, &itr.frame, itr.frame.sp)
+		throw("traceback stuck")
+	}
+
+	// Unwind to next frame.
+	setFuncInfoNoWB(&itr.frame.fn, flr)
+	itr.frame.pc = itr.frame.lr
+	itr.frame.lr = 0
+	itr.frame.sp = itr.frame.fp
+	itr.frame.fp = 0
+
+	// On link register architectures, sighandler saves the LR on stack
+	// before faking a call.
+	if usesLR && injectedCall {
+		x := *(*uintptr)(unsafe.Pointer(itr.frame.sp))
+		itr.frame.sp += alignUp(sys.MinFrameSize, sys.StackAlign)
+		f = findfunc(itr.frame.pc)
+		setFuncInfoNoWB(&itr.frame.fn, f)
+		if !f.valid() {
+			itr.frame.pc = x
+		} else if funcspdelta(f, itr.frame.pc, &itr.cache) == 0 {
+			itr.frame.lr = x
+		}
+	}
+	return itr.n < itr.max
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -12,18 +12,18 @@ import (
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	itr := tracebackIterator{
-		pc0:  pc0,
-		sp0:  sp0,
-		lr0:  lr0,
-		gp:   gp,
-		skip: skip,
-		// pcbuf:    pcbuf,
+		pc0:   pc0,
+		sp0:   sp0,
+		lr0:   lr0,
+		gp:    gp,
+		skip:  skip,
+		pcbuf: pcbuf,
 		// max:      max,
 		// callback: callback,
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(pcbuf, max, callback, v, flags)
+	return itr.Gentraceback(max, callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if itr.skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -87,7 +87,7 @@ func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback fun
 	waspanic := false
 	cgoCtxt := itr.gp.cgoCtxt
 	stack := itr.gp.stack
-	printing := pcbuf == nil && callback == nil
+	printing := itr.pcbuf == nil && callback == nil
 
 	// If the PC is zero, it's likely a nil function call.
 	// Start in the caller's frame.
@@ -342,7 +342,7 @@ func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback fun
 			}
 		}
 
-		if pcbuf != nil {
+		if itr.pcbuf != nil {
 			pc := frame.pc
 			// backup to CALL instruction to read inlining info (same logic as below)
 			tracepc := pc
@@ -376,7 +376,7 @@ func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback fun
 					} else if itr.skip > 0 {
 						itr.skip--
 					} else if n < max {
-						(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = pc
+						(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
 						n++
 					}
 					lastFuncID = inltree[ix].funcID
@@ -391,7 +391,7 @@ func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback fun
 			} else if itr.skip > 0 {
 				itr.skip--
 			} else if n < max {
-				(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = pc
+				(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
 				n++
 			}
 			lastFuncID = f.funcID
@@ -476,7 +476,7 @@ func (itr *tracebackIterator) Gentraceback(pcbuf *uintptr, max int, callback fun
 			// callback != nil only used when we only care
 			// about Go frames.
 			if itr.skip == 0 && callback == nil {
-				n = tracebackCgoContext(pcbuf, printing, ctxt, n, max)
+				n = tracebackCgoContext(itr.pcbuf, printing, ctxt, n, max)
 			}
 		}
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -11,6 +11,14 @@ import (
 )
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+	var itr tracebackIterator
+	return itr.Gentraceback(pc0, sp0, lr0, gp, skip, pcbuf, max, callback, v, flags)
+}
+
+type tracebackIterator struct {
+}
+
+func (itr *tracebackIterator) Gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -25,8 +25,61 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	}
 	if !itr.init() {
 		return 0
+	} else if !itr.Gentraceback() {
+		return itr.n
 	}
-	return itr.Gentraceback()
+
+	if itr.printing {
+		itr.n = itr.nprint
+	}
+
+	// Note that panic != nil is okay here: there can be leftover panics,
+	// because the defers on the panic stack do not nest in frame order as
+	// they do on the defer stack. If you have:
+	//
+	//	frame 1 defers d1
+	//	frame 2 defers d2
+	//	frame 3 defers d3
+	//	frame 4 panics
+	//	frame 4's panic starts running defers
+	//	frame 5, running d3, defers d4
+	//	frame 5 panics
+	//	frame 5's panic starts running defers
+	//	frame 6, running d4, garbage collects
+	//	frame 6, running d2, garbage collects
+	//
+	// During the execution of d4, the panic stack is d4 -> d3, which
+	// is nested properly, and we'll treat frame 3 as resumable, because we
+	// can find d3. (And in fact frame 3 is resumable. If d4 recovers
+	// and frame 5 continues running, d3, d3 can recover and we'll
+	// resume execution in (returning from) frame 3.)
+	//
+	// During the execution of d2, however, the panic stack is d2 -> d3,
+	// which is inverted. The scan will match d2 to frame 2 but having
+	// d2 on the stack until then means it will not match d3 to frame 3.
+	// This is okay: if we're running d2, then all the defers after d2 have
+	// completed and their corresponding frames are dead. Not finding d3
+	// for frame 3 means we'll set frame 3's continpc == 0, which is correct
+	// (frame 3 is dead). At the end of the walk the panic stack can thus
+	// contain defers (d3 in this case) for dead frames. The inversion here
+	// always indicates a dead frame, and the effect of the inversion on the
+	// scan is to hide those dead frames, so the scan is still okay:
+	// what's left on the panic stack are exactly (and only) the dead frames.
+	//
+	// We require callback != nil here because only when callback != nil
+	// do we know that gentraceback is being called in a "must be correct"
+	// context as opposed to a "best effort" context. The tracebacks with
+	// callbacks only happen when everything is stopped nicely.
+	// At other times, such as when gathering a stack for a profiling signal
+	// or when printing a traceback during a crash, everything may not be
+	// stopped nicely, and the stack walk may not be able to complete.
+	if itr.callback != nil && itr.n < itr.max && itr.frame.sp != itr.gp.stktopsp {
+		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(itr.frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
+		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", itr.n, " max=", itr.max, "\n")
+		throw("traceback did not unwind completely")
+	}
+
+	return itr.n
 }
 
 type tracebackIterator struct {
@@ -147,7 +200,7 @@ func (itr *tracebackIterator) init() bool {
 	return true
 }
 
-func (itr *tracebackIterator) Gentraceback() int {
+func (itr *tracebackIterator) Gentraceback() bool {
 	f := itr.frame.fn
 	for itr.n < itr.max {
 		// Typically:
@@ -355,7 +408,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 		if itr.callback != nil {
 			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
-				return itr.n
+				return false
 			}
 		}
 
@@ -533,58 +586,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			}
 		}
 	}
-
-	if itr.printing {
-		itr.n = itr.nprint
-	}
-
-	// Note that panic != nil is okay here: there can be leftover panics,
-	// because the defers on the panic stack do not nest in frame order as
-	// they do on the defer stack. If you have:
-	//
-	//	frame 1 defers d1
-	//	frame 2 defers d2
-	//	frame 3 defers d3
-	//	frame 4 panics
-	//	frame 4's panic starts running defers
-	//	frame 5, running d3, defers d4
-	//	frame 5 panics
-	//	frame 5's panic starts running defers
-	//	frame 6, running d4, garbage collects
-	//	frame 6, running d2, garbage collects
-	//
-	// During the execution of d4, the panic stack is d4 -> d3, which
-	// is nested properly, and we'll treat frame 3 as resumable, because we
-	// can find d3. (And in fact frame 3 is resumable. If d4 recovers
-	// and frame 5 continues running, d3, d3 can recover and we'll
-	// resume execution in (returning from) frame 3.)
-	//
-	// During the execution of d2, however, the panic stack is d2 -> d3,
-	// which is inverted. The scan will match d2 to frame 2 but having
-	// d2 on the stack until then means it will not match d3 to frame 3.
-	// This is okay: if we're running d2, then all the defers after d2 have
-	// completed and their corresponding frames are dead. Not finding d3
-	// for frame 3 means we'll set frame 3's continpc == 0, which is correct
-	// (frame 3 is dead). At the end of the walk the panic stack can thus
-	// contain defers (d3 in this case) for dead frames. The inversion here
-	// always indicates a dead frame, and the effect of the inversion on the
-	// scan is to hide those dead frames, so the scan is still okay:
-	// what's left on the panic stack are exactly (and only) the dead frames.
-	//
-	// We require callback != nil here because only when callback != nil
-	// do we know that gentraceback is being called in a "must be correct"
-	// context as opposed to a "best effort" context. The tracebacks with
-	// callbacks only happen when everything is stopped nicely.
-	// At other times, such as when gathering a stack for a profiling signal
-	// or when printing a traceback during a crash, everything may not be
-	// stopped nicely, and the stack walk may not be able to complete.
-	if itr.callback != nil && itr.n < itr.max && itr.frame.sp != itr.gp.stktopsp {
-		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(itr.frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
-		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", itr.n, " max=", itr.max, "\n")
-		throw("traceback did not unwind completely")
-	}
-
-	return itr.n
+	return true
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -170,6 +170,77 @@ type tracebackIterator struct {
 	flr         funcInfo
 }
 
+func (itr *tracebackIterator) Next() (foundFrame bool) {
+yield:
+	for {
+		switch itr.state {
+		case stateInit:
+			switch itr.event = itr.init(); itr.event {
+			case eventOK:
+				itr.state = statePreambleFrame
+			default:
+				itr.state = stateError
+				break yield
+			}
+
+		case statePreambleFrame:
+			switch itr.event = itr.preamble(); itr.event {
+			case eventPCBufInline:
+				itr.state = stateYieldInlineFrame
+			case eventBufNormal:
+				itr.state = stateYieldNormalFrame
+			case eventNoPCBuf:
+				itr.state = statePostamble
+			default:
+				itr.state = stateError
+				break yield
+			}
+
+		case stateYieldInlineFrame:
+			switch itr.event = itr.inlineFrame(); itr.event {
+			case eventPCBufInline:
+				itr.state = stateYieldInlineFrame
+				foundFrame = true
+				break yield
+			case eventBufNormal:
+				itr.state = stateYieldNormalFrame
+			default:
+				itr.state = stateError
+				break yield
+			}
+
+		case stateYieldNormalFrame:
+			switch itr.event = itr.normalFrame(); itr.event {
+			case eventOK:
+				itr.state = statePostamble
+				foundFrame = true
+				break yield
+			default:
+				itr.state = stateError
+				break yield
+			}
+
+		case statePostamble:
+			switch itr.event = itr.postamble(); itr.event {
+			case eventOK:
+				itr.state = statePreambleFrame
+			case eventBottomOfStack, eventMaxReached:
+				itr.state = stateDone
+			default:
+				itr.state = stateError
+				break yield
+			}
+
+		case stateDone, stateError:
+			break yield
+
+		default:
+			throw("bug")
+		}
+	}
+	return foundFrame
+}
+
 func (itr *tracebackIterator) init() tracebackEvent {
 	// Don't call this "g"; it's too easy get "g" and "gp" confused.
 	if ourg := getg(); ourg == itr.gp && ourg == ourg.m.curg {
@@ -252,77 +323,6 @@ func (itr *tracebackIterator) init() tracebackEvent {
 	itr.lastFuncID = funcID_normal
 
 	return eventOK
-}
-
-func (itr *tracebackIterator) Next() (foundFrame bool) {
-yield:
-	for {
-		switch itr.state {
-		case stateInit:
-			switch itr.event = itr.init(); itr.event {
-			case eventOK:
-				itr.state = statePreambleFrame
-			default:
-				itr.state = stateError
-				break yield
-			}
-
-		case statePreambleFrame:
-			switch itr.event = itr.preamble(); itr.event {
-			case eventPCBufInline:
-				itr.state = stateYieldInlineFrame
-			case eventBufNormal:
-				itr.state = stateYieldNormalFrame
-			case eventNoPCBuf:
-				itr.state = statePostamble
-			default:
-				itr.state = stateError
-				break yield
-			}
-
-		case stateYieldInlineFrame:
-			switch itr.event = itr.inlineFrame(); itr.event {
-			case eventPCBufInline:
-				itr.state = stateYieldInlineFrame
-				foundFrame = true
-				break yield
-			case eventBufNormal:
-				itr.state = stateYieldNormalFrame
-			default:
-				itr.state = stateError
-				break yield
-			}
-
-		case stateYieldNormalFrame:
-			switch itr.event = itr.normalFrame(); itr.event {
-			case eventOK:
-				itr.state = statePostamble
-				foundFrame = true
-				break yield
-			default:
-				itr.state = stateError
-				break yield
-			}
-
-		case statePostamble:
-			switch itr.event = itr.postamble(); itr.event {
-			case eventOK:
-				itr.state = statePreambleFrame
-			case eventBottomOfStack, eventMaxReached:
-				itr.state = stateDone
-			default:
-				itr.state = stateError
-				break yield
-			}
-
-		case stateDone, stateError:
-			break yield
-
-		default:
-			throw("bug")
-		}
-	}
-	return foundFrame
 }
 
 func (itr *tracebackIterator) preamble() tracebackEvent {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -42,6 +42,7 @@ type tracebackIterator struct {
 	frame    stkframe
 	waspanic bool
 	cgoCtxt  []uintptr
+	stack    stack
 }
 
 func (itr *tracebackIterator) init() {
@@ -93,12 +94,11 @@ func (itr *tracebackIterator) init() {
 
 	itr.waspanic = false
 	setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+	itr.stack = itr.gp.stack
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
 	frame := itr.frame
-
-	stack := itr.gp.stack
 	printing := itr.pcbuf == nil && itr.callback == nil
 
 	// If the PC is zero, it's likely a nil function call.
@@ -131,7 +131,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 	if !f.valid() {
 		if itr.callback != nil || printing {
 			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(frame.pc), "\n")
-			tracebackHexdump(stack, &frame, 0)
+			tracebackHexdump(itr.stack, &frame, 0)
 		}
 		if itr.callback != nil {
 			throw("unknown pc")
@@ -197,7 +197,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					flag = f.flag
 					frame.lr = itr.gp.sched.lr
 					frame.sp = itr.gp.sched.sp
-					stack = itr.gp.stack
+					itr.stack = itr.gp.stack
 					setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 				case funcID_systemstack:
 					// systemstack returns normally, so just follow the
@@ -215,7 +215,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					}
 					setGNoWB(&itr.gp, itr.gp.m.curg)
 					frame.sp = itr.gp.sched.sp
-					stack = itr.gp.stack
+					itr.stack = itr.gp.stack
 					setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 					flag &^= funcFlag_SPWRITE
 				}
@@ -284,7 +284,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 				}
 				if itr.callback != nil || doPrint {
 					print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(frame.lr), "\n")
-					tracebackHexdump(stack, &frame, lrPtr)
+					tracebackHexdump(itr.stack, &frame, lrPtr)
 				}
 				if itr.callback != nil {
 					throw("unknown caller pc")
@@ -503,7 +503,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 		if frame.pc == frame.lr && frame.sp == frame.fp {
 			// If the next frame is identical to the current frame, we cannot make progress.
 			print("runtime: traceback stuck. pc=", hex(frame.pc), " sp=", hex(frame.sp), "\n")
-			tracebackHexdump(stack, &frame, frame.sp)
+			tracebackHexdump(itr.stack, &frame, frame.sp)
 			throw("traceback stuck")
 		}
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -16,6 +16,7 @@ const (
 	tracebackOK tracebackError = iota
 	tracebackOwnStack
 	tracebackUnknownPC
+	tracebackUnexpectedSPWrite
 	tracebackUnexpectedReturnPC
 	tracebackStuck
 )
@@ -41,12 +42,14 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		printing: printing,
 	}
 
+	var n int
 	for itr.Next() {
 		if callback != nil {
 			if !callback((*stkframe)(noescape(unsafe.Pointer(itr.Frame()))), v) {
-				return itr.n
+				return n
 			}
 		}
+		n++
 	}
 
 	switch itr.Error() {
@@ -62,6 +65,11 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 			throw("unknown pc")
 		}
 		return 0 // tracebackUnknownPC happens in init()
+	case tracebackUnexpectedSPWrite:
+		if callback != nil && n > 1 {
+			println("traceback: unexpected SPWRITE function", funcname(itr.frame.fn))
+			throw("traceback")
+		}
 	}
 
 	if itr.printing {
@@ -346,8 +354,8 @@ func (itr *tracebackIterator) Next() bool {
 		// at the bottom frame of the stack. But farther up the stack we'd better not
 		// find any.
 		if itr.callback {
-			println("traceback: unexpected SPWRITE function", funcname(f))
-			throw("traceback")
+			itr.error = tracebackUnexpectedSPWrite
+			return false
 		}
 		itr.frame.lr = 0
 		flr = funcInfo{}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -19,7 +19,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		skip:     skip,
 		pcbuf:    pcbuf,
 		max:      max,
-		callback: callback,
+		callback: *(*func(*stkframe, unsafe.Pointer) bool)(noescape(unsafe.Pointer(&callback))),
 		v:        v,
 		flags:    flags,
 	}
@@ -39,6 +39,7 @@ type tracebackIterator struct {
 
 	level  int32
 	nprint int
+	frame  stkframe
 }
 
 func (itr *tracebackIterator) init() {
@@ -81,15 +82,17 @@ func (itr *tracebackIterator) init() {
 		}
 	}
 	itr.nprint = 0
+
+	itr.frame.pc = itr.pc0
+	itr.frame.sp = itr.sp0
+	if usesLR {
+		itr.frame.lr = itr.lr0
+	}
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
-	var frame stkframe
-	frame.pc = itr.pc0
-	frame.sp = itr.sp0
-	if usesLR {
-		frame.lr = itr.lr0
-	}
+	frame := itr.frame
+
 	waspanic := false
 	cgoCtxt := itr.gp.cgoCtxt
 	stack := itr.gp.stack

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -34,10 +34,6 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		}
 	}
 
-	if itr.callbackAbort {
-		return itr.n
-	}
-
 	if itr.printing {
 		itr.n = itr.nprint
 	}
@@ -100,18 +96,17 @@ type tracebackIterator struct {
 	callback      func(*stkframe, unsafe.Pointer) bool
 	flags         uint
 
-	level         int32
-	nprint        int
-	frame         stkframe
-	waspanic      bool
-	cgoCtxt       []uintptr
-	stack         stack
-	printing      bool
-	cache         pcvalueCache
-	lastFuncID    funcID
-	n             int
-	callbackAbort bool
-	currentFrame  stkframe // frame is already the next frame when Next() returns
+	level        int32
+	nprint       int
+	frame        stkframe
+	waspanic     bool
+	cgoCtxt      []uintptr
+	stack        stack
+	printing     bool
+	cache        pcvalueCache
+	lastFuncID   funcID
+	n            int
+	currentFrame stkframe // frame is already the next frame when Next() returns
 }
 
 func (itr *tracebackIterator) init() bool {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -15,7 +15,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		pc0: pc0,
 		sp0: sp0,
 		lr0: lr0,
-		// gp:       gp,
+		gp:  gp,
 		// skip:     skip,
 		// pcbuf:    pcbuf,
 		// max:      max,
@@ -23,7 +23,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(gp, skip, pcbuf, max, callback, v, flags)
+	return itr.Gentraceback(skip, pcbuf, max, callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,13 +37,13 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
 
 	// Don't call this "g"; it's too easy get "g" and "gp" confused.
-	if ourg := getg(); ourg == gp && ourg == ourg.m.curg {
+	if ourg := getg(); ourg == itr.gp && ourg == ourg.m.curg {
 		// The starting sp has been passed in as a uintptr, and the caller may
 		// have other uintptr-typed stack references as well.
 		// If during one of the calls that got us here or during one of the
@@ -62,17 +62,17 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 	level, _, _ := gotraceback()
 
 	if itr.pc0 == ^uintptr(0) && itr.sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
-		if gp.syscallsp != 0 {
-			itr.pc0 = gp.syscallpc
-			itr.sp0 = gp.syscallsp
+		if itr.gp.syscallsp != 0 {
+			itr.pc0 = itr.gp.syscallpc
+			itr.sp0 = itr.gp.syscallsp
 			if usesLR {
 				itr.lr0 = 0
 			}
 		} else {
-			itr.pc0 = gp.sched.pc
-			itr.sp0 = gp.sched.sp
+			itr.pc0 = itr.gp.sched.pc
+			itr.sp0 = itr.gp.sched.sp
 			if usesLR {
-				itr.lr0 = gp.sched.lr
+				itr.lr0 = itr.gp.sched.lr
 			}
 		}
 	}
@@ -85,8 +85,8 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 		frame.lr = itr.lr0
 	}
 	waspanic := false
-	cgoCtxt := gp.cgoCtxt
-	stack := gp.stack
+	cgoCtxt := itr.gp.cgoCtxt
+	stack := itr.gp.stack
 	printing := pcbuf == nil && callback == nil
 
 	// If the PC is zero, it's likely a nil function call.
@@ -118,7 +118,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 	f := findfunc(frame.pc)
 	if !f.valid() {
 		if callback != nil || printing {
-			print("runtime: g ", gp.goid, ": unknown pc ", hex(frame.pc), "\n")
+			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(frame.pc), "\n")
 			tracebackHexdump(stack, &frame, 0)
 		}
 		if callback != nil {
@@ -155,7 +155,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 			// So we don't need to exclude it with the other SP-writing functions.
 			flag &^= funcFlag_SPWRITE
 		}
-		if frame.pc == itr.pc0 && frame.sp == itr.sp0 && itr.pc0 == gp.syscallpc && itr.sp0 == gp.syscallsp {
+		if frame.pc == itr.pc0 && frame.sp == itr.sp0 && itr.pc0 == itr.gp.syscallpc && itr.sp0 == itr.gp.syscallsp {
 			// Some Syscall functions write to SP, but they do so only after
 			// saving the entry PC/SP using entersyscall.
 			// Since we are using the entry PC/SP, the later SP write doesn't matter.
@@ -170,7 +170,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 			// We also defensively check that this won't switch M's on us,
 			// which could happen at critical points in the scheduler.
 			// This ensures gp.m doesn't change from a stack jump.
-			if flags&_TraceJumpStack != 0 && gp == gp.m.g0 && gp.m.curg != nil && gp.m.curg.m == gp.m {
+			if flags&_TraceJumpStack != 0 && itr.gp == itr.gp.m.g0 && itr.gp.m.curg != nil && itr.gp.m.curg.m == itr.gp.m {
 				switch f.funcID {
 				case funcID_morestack:
 					// morestack does not return normally -- newstack()
@@ -178,15 +178,15 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 					// This keeps morestack() from showing up in the backtrace,
 					// but that makes some sense since it'll never be returned
 					// to.
-					gp = gp.m.curg
-					frame.pc = gp.sched.pc
+					setGNoWB(&itr.gp, itr.gp.m.curg)
+					frame.pc = itr.gp.sched.pc
 					frame.fn = findfunc(frame.pc)
 					f = frame.fn
 					flag = f.flag
-					frame.lr = gp.sched.lr
-					frame.sp = gp.sched.sp
-					stack = gp.stack
-					cgoCtxt = gp.cgoCtxt
+					frame.lr = itr.gp.sched.lr
+					frame.sp = itr.gp.sched.sp
+					stack = itr.gp.stack
+					cgoCtxt = itr.gp.cgoCtxt
 				case funcID_systemstack:
 					// systemstack returns normally, so just follow the
 					// stack transition.
@@ -201,10 +201,10 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 						flag &^= funcFlag_SPWRITE
 						break
 					}
-					gp = gp.m.curg
-					frame.sp = gp.sched.sp
-					stack = gp.stack
-					cgoCtxt = gp.cgoCtxt
+					setGNoWB(&itr.gp, itr.gp.m.curg)
+					frame.sp = itr.gp.sched.sp
+					stack = itr.gp.stack
+					cgoCtxt = itr.gp.cgoCtxt
 					flag &^= funcFlag_SPWRITE
 				}
 			}
@@ -263,7 +263,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 				// But if callback is set, we're doing a garbage collection and must
 				// get everything, so crash loudly.
 				doPrint := printing
-				if doPrint && gp.m.incgo && f.funcID == funcID_sigpanic {
+				if doPrint && itr.gp.m.incgo && f.funcID == funcID_sigpanic {
 					// We can inject sigpanic
 					// calls directly into C code,
 					// in which case we'll see a C
@@ -271,7 +271,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 					doPrint = false
 				}
 				if callback != nil || doPrint {
-					print("runtime: g ", gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(frame.lr), "\n")
+					print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(frame.lr), "\n")
 					tracebackHexdump(stack, &frame, lrPtr)
 				}
 				if callback != nil {
@@ -428,7 +428,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 					inlFunc.funcID = inltree[ix].funcID
 					inlFunc.startLine = inltree[ix].startLine
 
-					if (flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, gp, nprint == 0, inlFuncInfo.funcID, lastFuncID) {
+					if (flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, nprint == 0, inlFuncInfo.funcID, lastFuncID) {
 						name := funcname(inlFuncInfo)
 						file, line := funcline(f, tracepc)
 						print(name, "(...)\n")
@@ -440,7 +440,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
 				}
 			}
-			if (flags&_TraceRuntimeFrames) != 0 || showframe(f, gp, nprint == 0, f.funcID, lastFuncID) {
+			if (flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, nprint == 0, f.funcID, lastFuncID) {
 				// Print during crash.
 				//	main(0x1, 0x2, 0x3)
 				//		/home/rsc/go/src/runtime/x.go:23 +0xf
@@ -458,7 +458,7 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 				if frame.pc > f.entry() {
 					print(" +", hex(frame.pc-f.entry()))
 				}
-				if gp.m != nil && gp.m.throwing >= throwTypeRuntime && gp == gp.m.curg || level >= 2 {
+				if itr.gp.m != nil && itr.gp.m.throwing >= throwTypeRuntime && itr.gp == itr.gp.m.curg || level >= 2 {
 					print(" fp=", hex(frame.fp), " sp=", hex(frame.sp), " pc=", hex(frame.pc))
 				}
 				print("\n")
@@ -561,9 +561,9 @@ func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max 
 	// At other times, such as when gathering a stack for a profiling signal
 	// or when printing a traceback during a crash, everything may not be
 	// stopped nicely, and the stack walk may not be able to complete.
-	if callback != nil && n < max && frame.sp != gp.stktopsp {
-		print("runtime: g", gp.goid, ": frame.sp=", hex(frame.sp), " top=", hex(gp.stktopsp), "\n")
-		print("\tstack=[", hex(gp.stack.lo), "-", hex(gp.stack.hi), "] n=", n, " max=", max, "\n")
+	if callback != nil && n < max && frame.sp != itr.gp.stktopsp {
+		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
+		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", n, " max=", max, "\n")
 		throw("traceback did not unwind completely")
 	}
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -280,9 +280,23 @@ loop:
 				break loop
 			}
 		case stateBufInlineFrame:
-			itr.state, itr.event = itr.inlineFrame()
+			switch itr.event = itr.inlineFrame(); itr.event {
+			case eventPCBufInline:
+				itr.state = stateBufInlineFrame
+			case eventBufNormal:
+				itr.state = stateBufNormalFrame
+			default:
+				itr.state = stateError
+				break loop
+			}
 		case stateBufNormalFrame:
-			itr.state, itr.event = itr.normalFrame()
+			switch itr.event = itr.normalFrame(); itr.event {
+			case eventOK:
+				itr.state = statePostamble
+			default:
+				itr.state = stateError
+				break loop
+			}
 		case statePostamble:
 			more = itr.next()
 			if more {
@@ -549,14 +563,14 @@ func (itr *tracebackIterator) prepareFrame() tracebackEvent {
 	return eventNoPCBuf
 }
 
-func (itr *tracebackIterator) inlineFrame() (tracebackState, tracebackEvent) {
+func (itr *tracebackIterator) inlineFrame() tracebackEvent {
 	f := itr.frame.fn
 
 	inltree := (*[1 << 20]inlinedCall)(itr.inldata)
 
 	ix := pcdatavalue(f, _PCDATA_InlTreeIndex, itr.tracepc, &itr.cache)
 	if ix < 0 {
-		return stateBufNormalFrame, eventOK
+		return eventBufNormal
 	}
 
 	if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
@@ -572,10 +586,10 @@ func (itr *tracebackIterator) inlineFrame() (tracebackState, tracebackEvent) {
 	itr.tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 	itr.pc = itr.tracepc + 1
 
-	return stateBufInlineFrame, eventOK
+	return eventPCBufInline
 }
 
-func (itr *tracebackIterator) normalFrame() (tracebackState, tracebackEvent) {
+func (itr *tracebackIterator) normalFrame() tracebackEvent {
 	f := itr.frame.fn
 
 	// Record the main frame.
@@ -590,7 +604,7 @@ func (itr *tracebackIterator) normalFrame() (tracebackState, tracebackEvent) {
 	itr.lastFuncID = f.funcID
 	itr.n-- // offset n++ below
 
-	return statePostamble, eventOK
+	return eventOK
 }
 
 func (itr *tracebackIterator) next() bool {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -48,6 +48,7 @@ type tracebackIterator struct {
 	printing   bool
 	cache      pcvalueCache
 	lastFuncID funcID
+	n          int
 }
 
 func (itr *tracebackIterator) init() bool {
@@ -148,8 +149,7 @@ func (itr *tracebackIterator) init() bool {
 
 func (itr *tracebackIterator) Gentraceback() int {
 	f := itr.frame.fn
-	n := 0
-	for n < itr.max {
+	for itr.n < itr.max {
 		// Typically:
 		//	pc is the PC of the running function.
 		//	sp is the stack pointer at that program counter.
@@ -236,7 +236,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// This function marks the top of the stack. Stop the traceback.
 			itr.frame.lr = 0
 			flr = funcInfo{}
-		} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || n > 0) {
+		} else if flag&funcFlag_SPWRITE != 0 && (itr.callback == nil || itr.n > 0) {
 			// The function we are in does a write to SP that we don't know
 			// how to encode in the spdelta table. Examples include context
 			// switch routines like runtime.gogo but also any code that switches
@@ -263,7 +263,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 		} else {
 			var lrPtr uintptr
 			if usesLR {
-				if n == 0 && itr.frame.sp < itr.frame.fp || itr.frame.lr == 0 {
+				if itr.n == 0 && itr.frame.sp < itr.frame.fp || itr.frame.lr == 0 {
 					lrPtr = itr.frame.sp
 					itr.frame.lr = *(*uintptr)(unsafe.Pointer(lrPtr))
 				}
@@ -355,7 +355,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 		if itr.callback != nil {
 			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
-				return n
+				return itr.n
 			}
 		}
 
@@ -374,7 +374,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// See issue 34123.
 			// The pc can be at function entry when the frame is initialized without
 			// actually running code, like runtime.mstart.
-			if (n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || pc == f.entry() {
+			if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || pc == f.entry() {
 				pc++
 			} else {
 				tracepc--
@@ -392,9 +392,9 @@ func (itr *tracebackIterator) Gentraceback() int {
 						// ignore wrappers
 					} else if itr.skip > 0 {
 						itr.skip--
-					} else if n < itr.max {
-						(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
-						n++
+					} else if itr.n < itr.max {
+						(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
+						itr.n++
 					}
 					itr.lastFuncID = inltree[ix].funcID
 					// Back up to an instruction in the "caller".
@@ -407,12 +407,12 @@ func (itr *tracebackIterator) Gentraceback() int {
 				// Ignore wrapper functions (except when they trigger panics).
 			} else if itr.skip > 0 {
 				itr.skip--
-			} else if n < itr.max {
-				(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
-				n++
+			} else if itr.n < itr.max {
+				(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
+				itr.n++
 			}
 			itr.lastFuncID = f.funcID
-			n-- // offset n++ below
+			itr.n-- // offset n++ below
 		}
 
 		if itr.printing {
@@ -425,7 +425,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 			// backup to CALL instruction to read inlining info (same logic as below)
 			tracepc := itr.frame.pc
-			if (n > 0 || itr.flags&_TraceTrap == 0) && itr.frame.pc > f.entry() && !itr.waspanic {
+			if (itr.n > 0 || itr.flags&_TraceTrap == 0) && itr.frame.pc > f.entry() && !itr.waspanic {
 				tracepc--
 			}
 			// If there is inlining info, print the inner frames.
@@ -483,7 +483,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			}
 			itr.lastFuncID = f.funcID
 		}
-		n++
+		itr.n++
 
 		if f.funcID == funcID_cgocallback && len(itr.cgoCtxt) > 0 {
 			ctxt := itr.cgoCtxt[len(itr.cgoCtxt)-1]
@@ -493,7 +493,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// callback != nil only used when we only care
 			// about Go frames.
 			if itr.skip == 0 && itr.callback == nil {
-				n = tracebackCgoContext(itr.pcbuf, itr.printing, ctxt, n, itr.max)
+				itr.n = tracebackCgoContext(itr.pcbuf, itr.printing, ctxt, itr.n, itr.max)
 			}
 		}
 
@@ -535,7 +535,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 	}
 
 	if itr.printing {
-		n = itr.nprint
+		itr.n = itr.nprint
 	}
 
 	// Note that panic != nil is okay here: there can be leftover panics,
@@ -578,14 +578,13 @@ func (itr *tracebackIterator) Gentraceback() int {
 	// At other times, such as when gathering a stack for a profiling signal
 	// or when printing a traceback during a crash, everything may not be
 	// stopped nicely, and the stack walk may not be able to complete.
-	if itr.callback != nil && n < itr.max && itr.frame.sp != itr.gp.stktopsp {
+	if itr.callback != nil && itr.n < itr.max && itr.frame.sp != itr.gp.stktopsp {
 		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(itr.frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
-		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", n, " max=", itr.max, "\n")
+		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", itr.n, " max=", itr.max, "\n")
 		throw("traceback did not unwind completely")
 	}
 
-	return n
-
+	return itr.n
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -1,0 +1,545 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	"internal/goarch"
+	"runtime/internal/sys"
+	"unsafe"
+)
+
+func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+	if skip > 0 && callback != nil {
+		throw("gentraceback callback cannot be used with non-zero skip")
+	}
+
+	// Don't call this "g"; it's too easy get "g" and "gp" confused.
+	if ourg := getg(); ourg == gp && ourg == ourg.m.curg {
+		// The starting sp has been passed in as a uintptr, and the caller may
+		// have other uintptr-typed stack references as well.
+		// If during one of the calls that got us here or during one of the
+		// callbacks below the stack must be grown, all these uintptr references
+		// to the stack will not be updated, and gentraceback will continue
+		// to inspect the old stack memory, which may no longer be valid.
+		// Even if all the variables were updated correctly, it is not clear that
+		// we want to expose a traceback that begins on one stack and ends
+		// on another stack. That could confuse callers quite a bit.
+		// Instead, we require that gentraceback and any other function that
+		// accepts an sp for the current goroutine (typically obtained by
+		// calling getcallersp) must not run on that goroutine's stack but
+		// instead on the g0 stack.
+		throw("gentraceback cannot trace user goroutine on its own stack")
+	}
+	level, _, _ := gotraceback()
+
+	if pc0 == ^uintptr(0) && sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
+		if gp.syscallsp != 0 {
+			pc0 = gp.syscallpc
+			sp0 = gp.syscallsp
+			if usesLR {
+				lr0 = 0
+			}
+		} else {
+			pc0 = gp.sched.pc
+			sp0 = gp.sched.sp
+			if usesLR {
+				lr0 = gp.sched.lr
+			}
+		}
+	}
+
+	nprint := 0
+	var frame stkframe
+	frame.pc = pc0
+	frame.sp = sp0
+	if usesLR {
+		frame.lr = lr0
+	}
+	waspanic := false
+	cgoCtxt := gp.cgoCtxt
+	stack := gp.stack
+	printing := pcbuf == nil && callback == nil
+
+	// If the PC is zero, it's likely a nil function call.
+	// Start in the caller's frame.
+	if frame.pc == 0 {
+		if usesLR {
+			frame.pc = *(*uintptr)(unsafe.Pointer(frame.sp))
+			frame.lr = 0
+		} else {
+			frame.pc = uintptr(*(*uintptr)(unsafe.Pointer(frame.sp)))
+			frame.sp += goarch.PtrSize
+		}
+	}
+
+	// runtime/internal/atomic functions call into kernel helpers on
+	// arm < 7. See runtime/internal/atomic/sys_linux_arm.s.
+	//
+	// Start in the caller's frame.
+	if GOARCH == "arm" && goarm < 7 && GOOS == "linux" && frame.pc&0xffff0000 == 0xffff0000 {
+		// Note that the calls are simple BL without pushing the return
+		// address, so we use LR directly.
+		//
+		// The kernel helpers are frameless leaf functions, so SP and
+		// LR are not touched.
+		frame.pc = frame.lr
+		frame.lr = 0
+	}
+
+	f := findfunc(frame.pc)
+	if !f.valid() {
+		if callback != nil || printing {
+			print("runtime: g ", gp.goid, ": unknown pc ", hex(frame.pc), "\n")
+			tracebackHexdump(stack, &frame, 0)
+		}
+		if callback != nil {
+			throw("unknown pc")
+		}
+		return 0
+	}
+	frame.fn = f
+
+	var cache pcvalueCache
+
+	lastFuncID := funcID_normal
+	n := 0
+	for n < max {
+		// Typically:
+		//	pc is the PC of the running function.
+		//	sp is the stack pointer at that program counter.
+		//	fp is the frame pointer (caller's stack pointer) at that program counter, or nil if unknown.
+		//	stk is the stack containing sp.
+		//	The caller's program counter is lr, unless lr is zero, in which case it is *(uintptr*)sp.
+		f = frame.fn
+		if f.pcsp == 0 {
+			// No frame information, must be external function, like race support.
+			// See golang.org/issue/13568.
+			break
+		}
+
+		// Compute function info flags.
+		flag := f.flag
+		if f.funcID == funcID_cgocallback {
+			// cgocallback does write SP to switch from the g0 to the curg stack,
+			// but it carefully arranges that during the transition BOTH stacks
+			// have cgocallback frame valid for unwinding through.
+			// So we don't need to exclude it with the other SP-writing functions.
+			flag &^= funcFlag_SPWRITE
+		}
+		if frame.pc == pc0 && frame.sp == sp0 && pc0 == gp.syscallpc && sp0 == gp.syscallsp {
+			// Some Syscall functions write to SP, but they do so only after
+			// saving the entry PC/SP using entersyscall.
+			// Since we are using the entry PC/SP, the later SP write doesn't matter.
+			flag &^= funcFlag_SPWRITE
+		}
+
+		// Found an actual function.
+		// Derive frame pointer and link register.
+		if frame.fp == 0 {
+			// Jump over system stack transitions. If we're on g0 and there's a user
+			// goroutine, try to jump. Otherwise this is a regular call.
+			// We also defensively check that this won't switch M's on us,
+			// which could happen at critical points in the scheduler.
+			// This ensures gp.m doesn't change from a stack jump.
+			if flags&_TraceJumpStack != 0 && gp == gp.m.g0 && gp.m.curg != nil && gp.m.curg.m == gp.m {
+				switch f.funcID {
+				case funcID_morestack:
+					// morestack does not return normally -- newstack()
+					// gogo's to curg.sched. Match that.
+					// This keeps morestack() from showing up in the backtrace,
+					// but that makes some sense since it'll never be returned
+					// to.
+					gp = gp.m.curg
+					frame.pc = gp.sched.pc
+					frame.fn = findfunc(frame.pc)
+					f = frame.fn
+					flag = f.flag
+					frame.lr = gp.sched.lr
+					frame.sp = gp.sched.sp
+					stack = gp.stack
+					cgoCtxt = gp.cgoCtxt
+				case funcID_systemstack:
+					// systemstack returns normally, so just follow the
+					// stack transition.
+					if usesLR && funcspdelta(f, frame.pc, &cache) == 0 {
+						// We're at the function prologue and the stack
+						// switch hasn't happened, or epilogue where we're
+						// about to return. Just unwind normally.
+						// Do this only on LR machines because on x86
+						// systemstack doesn't have an SP delta (the CALL
+						// instruction opens the frame), therefore no way
+						// to check.
+						flag &^= funcFlag_SPWRITE
+						break
+					}
+					gp = gp.m.curg
+					frame.sp = gp.sched.sp
+					stack = gp.stack
+					cgoCtxt = gp.cgoCtxt
+					flag &^= funcFlag_SPWRITE
+				}
+			}
+			frame.fp = frame.sp + uintptr(funcspdelta(f, frame.pc, &cache))
+			if !usesLR {
+				// On x86, call instruction pushes return PC before entering new function.
+				frame.fp += goarch.PtrSize
+			}
+		}
+		var flr funcInfo
+		if flag&funcFlag_TOPFRAME != 0 {
+			// This function marks the top of the stack. Stop the traceback.
+			frame.lr = 0
+			flr = funcInfo{}
+		} else if flag&funcFlag_SPWRITE != 0 && (callback == nil || n > 0) {
+			// The function we are in does a write to SP that we don't know
+			// how to encode in the spdelta table. Examples include context
+			// switch routines like runtime.gogo but also any code that switches
+			// to the g0 stack to run host C code. Since we can't reliably unwind
+			// the SP (we might not even be on the stack we think we are),
+			// we stop the traceback here.
+			// This only applies for profiling signals (callback == nil).
+			//
+			// For a GC stack traversal (callback != nil), we should only see
+			// a function when it has voluntarily preempted itself on entry
+			// during the stack growth check. In that case, the function has
+			// not yet had a chance to do any writes to SP and is safe to unwind.
+			// isAsyncSafePoint does not allow assembly functions to be async preempted,
+			// and preemptPark double-checks that SPWRITE functions are not async preempted.
+			// So for GC stack traversal we leave things alone (this if body does not execute for n == 0)
+			// at the bottom frame of the stack. But farther up the stack we'd better not
+			// find any.
+			if callback != nil {
+				println("traceback: unexpected SPWRITE function", funcname(f))
+				throw("traceback")
+			}
+			frame.lr = 0
+			flr = funcInfo{}
+		} else {
+			var lrPtr uintptr
+			if usesLR {
+				if n == 0 && frame.sp < frame.fp || frame.lr == 0 {
+					lrPtr = frame.sp
+					frame.lr = *(*uintptr)(unsafe.Pointer(lrPtr))
+				}
+			} else {
+				if frame.lr == 0 {
+					lrPtr = frame.fp - goarch.PtrSize
+					frame.lr = uintptr(*(*uintptr)(unsafe.Pointer(lrPtr)))
+				}
+			}
+			flr = findfunc(frame.lr)
+			if !flr.valid() {
+				// This happens if you get a profiling interrupt at just the wrong time.
+				// In that context it is okay to stop early.
+				// But if callback is set, we're doing a garbage collection and must
+				// get everything, so crash loudly.
+				doPrint := printing
+				if doPrint && gp.m.incgo && f.funcID == funcID_sigpanic {
+					// We can inject sigpanic
+					// calls directly into C code,
+					// in which case we'll see a C
+					// return PC. Don't complain.
+					doPrint = false
+				}
+				if callback != nil || doPrint {
+					print("runtime: g ", gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(frame.lr), "\n")
+					tracebackHexdump(stack, &frame, lrPtr)
+				}
+				if callback != nil {
+					throw("unknown caller pc")
+				}
+			}
+		}
+
+		frame.varp = frame.fp
+		if !usesLR {
+			// On x86, call instruction pushes return PC before entering new function.
+			frame.varp -= goarch.PtrSize
+		}
+
+		// For architectures with frame pointers, if there's
+		// a frame, then there's a saved frame pointer here.
+		//
+		// NOTE: This code is not as general as it looks.
+		// On x86, the ABI is to save the frame pointer word at the
+		// top of the stack frame, so we have to back down over it.
+		// On arm64, the frame pointer should be at the bottom of
+		// the stack (with R29 (aka FP) = RSP), in which case we would
+		// not want to do the subtraction here. But we started out without
+		// any frame pointer, and when we wanted to add it, we didn't
+		// want to break all the assembly doing direct writes to 8(RSP)
+		// to set the first parameter to a called function.
+		// So we decided to write the FP link *below* the stack pointer
+		// (with R29 = RSP - 8 in Go functions).
+		// This is technically ABI-compatible but not standard.
+		// And it happens to end up mimicking the x86 layout.
+		// Other architectures may make different decisions.
+		if frame.varp > frame.sp && framepointer_enabled {
+			frame.varp -= goarch.PtrSize
+		}
+
+		frame.argp = frame.fp + sys.MinFrameSize
+
+		// Determine frame's 'continuation PC', where it can continue.
+		// Normally this is the return address on the stack, but if sigpanic
+		// is immediately below this function on the stack, then the frame
+		// stopped executing due to a trap, and frame.pc is probably not
+		// a safe point for looking up liveness information. In this panicking case,
+		// the function either doesn't return at all (if it has no defers or if the
+		// defers do not recover) or it returns from one of the calls to
+		// deferproc a second time (if the corresponding deferred func recovers).
+		// In the latter case, use a deferreturn call site as the continuation pc.
+		frame.continpc = frame.pc
+		if waspanic {
+			if frame.fn.deferreturn != 0 {
+				frame.continpc = frame.fn.entry() + uintptr(frame.fn.deferreturn) + 1
+				// Note: this may perhaps keep return variables alive longer than
+				// strictly necessary, as we are using "function has a defer statement"
+				// as a proxy for "function actually deferred something". It seems
+				// to be a minor drawback. (We used to actually look through the
+				// gp._defer for a defer corresponding to this function, but that
+				// is hard to do with defer records on the stack during a stack copy.)
+				// Note: the +1 is to offset the -1 that
+				// stack.go:getStackMap does to back up a return
+				// address make sure the pc is in the CALL instruction.
+			} else {
+				frame.continpc = 0
+			}
+		}
+
+		if callback != nil {
+			if !callback((*stkframe)(noescape(unsafe.Pointer(&frame))), v) {
+				return n
+			}
+		}
+
+		if pcbuf != nil {
+			pc := frame.pc
+			// backup to CALL instruction to read inlining info (same logic as below)
+			tracepc := pc
+			// Normally, pc is a return address. In that case, we want to look up
+			// file/line information using pc-1, because that is the pc of the
+			// call instruction (more precisely, the last byte of the call instruction).
+			// Callers expect the pc buffer to contain return addresses and do the
+			// same -1 themselves, so we keep pc unchanged.
+			// When the pc is from a signal (e.g. profiler or segv) then we want
+			// to look up file/line information using pc, and we store pc+1 in the
+			// pc buffer so callers can unconditionally subtract 1 before looking up.
+			// See issue 34123.
+			// The pc can be at function entry when the frame is initialized without
+			// actually running code, like runtime.mstart.
+			if (n == 0 && flags&_TraceTrap != 0) || waspanic || pc == f.entry() {
+				pc++
+			} else {
+				tracepc--
+			}
+
+			// If there is inlining info, record the inner frames.
+			if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
+				inltree := (*[1 << 20]inlinedCall)(inldata)
+				for {
+					ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, &cache)
+					if ix < 0 {
+						break
+					}
+					if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(lastFuncID) {
+						// ignore wrappers
+					} else if skip > 0 {
+						skip--
+					} else if n < max {
+						(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = pc
+						n++
+					}
+					lastFuncID = inltree[ix].funcID
+					// Back up to an instruction in the "caller".
+					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
+					pc = tracepc + 1
+				}
+			}
+			// Record the main frame.
+			if f.funcID == funcID_wrapper && elideWrapperCalling(lastFuncID) {
+				// Ignore wrapper functions (except when they trigger panics).
+			} else if skip > 0 {
+				skip--
+			} else if n < max {
+				(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = pc
+				n++
+			}
+			lastFuncID = f.funcID
+			n-- // offset n++ below
+		}
+
+		if printing {
+			// assume skip=0 for printing.
+			//
+			// Never elide wrappers if we haven't printed
+			// any frames. And don't elide wrappers that
+			// called panic rather than the wrapped
+			// function. Otherwise, leave them out.
+
+			// backup to CALL instruction to read inlining info (same logic as below)
+			tracepc := frame.pc
+			if (n > 0 || flags&_TraceTrap == 0) && frame.pc > f.entry() && !waspanic {
+				tracepc--
+			}
+			// If there is inlining info, print the inner frames.
+			if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
+				inltree := (*[1 << 20]inlinedCall)(inldata)
+				var inlFunc _func
+				inlFuncInfo := funcInfo{&inlFunc, f.datap}
+				for {
+					ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, nil)
+					if ix < 0 {
+						break
+					}
+
+					// Create a fake _func for the
+					// inlined function.
+					inlFunc.nameOff = inltree[ix].nameOff
+					inlFunc.funcID = inltree[ix].funcID
+					inlFunc.startLine = inltree[ix].startLine
+
+					if (flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, gp, nprint == 0, inlFuncInfo.funcID, lastFuncID) {
+						name := funcname(inlFuncInfo)
+						file, line := funcline(f, tracepc)
+						print(name, "(...)\n")
+						print("\t", file, ":", line, "\n")
+						nprint++
+					}
+					lastFuncID = inltree[ix].funcID
+					// Back up to an instruction in the "caller".
+					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
+				}
+			}
+			if (flags&_TraceRuntimeFrames) != 0 || showframe(f, gp, nprint == 0, f.funcID, lastFuncID) {
+				// Print during crash.
+				//	main(0x1, 0x2, 0x3)
+				//		/home/rsc/go/src/runtime/x.go:23 +0xf
+				//
+				name := funcname(f)
+				file, line := funcline(f, tracepc)
+				if name == "runtime.gopanic" {
+					name = "panic"
+				}
+				print(name, "(")
+				argp := unsafe.Pointer(frame.argp)
+				printArgs(f, argp, tracepc)
+				print(")\n")
+				print("\t", file, ":", line)
+				if frame.pc > f.entry() {
+					print(" +", hex(frame.pc-f.entry()))
+				}
+				if gp.m != nil && gp.m.throwing >= throwTypeRuntime && gp == gp.m.curg || level >= 2 {
+					print(" fp=", hex(frame.fp), " sp=", hex(frame.sp), " pc=", hex(frame.pc))
+				}
+				print("\n")
+				nprint++
+			}
+			lastFuncID = f.funcID
+		}
+		n++
+
+		if f.funcID == funcID_cgocallback && len(cgoCtxt) > 0 {
+			ctxt := cgoCtxt[len(cgoCtxt)-1]
+			cgoCtxt = cgoCtxt[:len(cgoCtxt)-1]
+
+			// skip only applies to Go frames.
+			// callback != nil only used when we only care
+			// about Go frames.
+			if skip == 0 && callback == nil {
+				n = tracebackCgoContext(pcbuf, printing, ctxt, n, max)
+			}
+		}
+
+		waspanic = f.funcID == funcID_sigpanic
+		injectedCall := waspanic || f.funcID == funcID_asyncPreempt || f.funcID == funcID_debugCallV2
+
+		// Do not unwind past the bottom of the stack.
+		if !flr.valid() {
+			break
+		}
+
+		if frame.pc == frame.lr && frame.sp == frame.fp {
+			// If the next frame is identical to the current frame, we cannot make progress.
+			print("runtime: traceback stuck. pc=", hex(frame.pc), " sp=", hex(frame.sp), "\n")
+			tracebackHexdump(stack, &frame, frame.sp)
+			throw("traceback stuck")
+		}
+
+		// Unwind to next frame.
+		frame.fn = flr
+		frame.pc = frame.lr
+		frame.lr = 0
+		frame.sp = frame.fp
+		frame.fp = 0
+
+		// On link register architectures, sighandler saves the LR on stack
+		// before faking a call.
+		if usesLR && injectedCall {
+			x := *(*uintptr)(unsafe.Pointer(frame.sp))
+			frame.sp += alignUp(sys.MinFrameSize, sys.StackAlign)
+			f = findfunc(frame.pc)
+			frame.fn = f
+			if !f.valid() {
+				frame.pc = x
+			} else if funcspdelta(f, frame.pc, &cache) == 0 {
+				frame.lr = x
+			}
+		}
+	}
+
+	if printing {
+		n = nprint
+	}
+
+	// Note that panic != nil is okay here: there can be leftover panics,
+	// because the defers on the panic stack do not nest in frame order as
+	// they do on the defer stack. If you have:
+	//
+	//	frame 1 defers d1
+	//	frame 2 defers d2
+	//	frame 3 defers d3
+	//	frame 4 panics
+	//	frame 4's panic starts running defers
+	//	frame 5, running d3, defers d4
+	//	frame 5 panics
+	//	frame 5's panic starts running defers
+	//	frame 6, running d4, garbage collects
+	//	frame 6, running d2, garbage collects
+	//
+	// During the execution of d4, the panic stack is d4 -> d3, which
+	// is nested properly, and we'll treat frame 3 as resumable, because we
+	// can find d3. (And in fact frame 3 is resumable. If d4 recovers
+	// and frame 5 continues running, d3, d3 can recover and we'll
+	// resume execution in (returning from) frame 3.)
+	//
+	// During the execution of d2, however, the panic stack is d2 -> d3,
+	// which is inverted. The scan will match d2 to frame 2 but having
+	// d2 on the stack until then means it will not match d3 to frame 3.
+	// This is okay: if we're running d2, then all the defers after d2 have
+	// completed and their corresponding frames are dead. Not finding d3
+	// for frame 3 means we'll set frame 3's continpc == 0, which is correct
+	// (frame 3 is dead). At the end of the walk the panic stack can thus
+	// contain defers (d3 in this case) for dead frames. The inversion here
+	// always indicates a dead frame, and the effect of the inversion on the
+	// scan is to hide those dead frames, so the scan is still okay:
+	// what's left on the panic stack are exactly (and only) the dead frames.
+	//
+	// We require callback != nil here because only when callback != nil
+	// do we know that gentraceback is being called in a "must be correct"
+	// context as opposed to a "best effort" context. The tracebacks with
+	// callbacks only happen when everything is stopped nicely.
+	// At other times, such as when gathering a stack for a profiling signal
+	// or when printing a traceback during a crash, everything may not be
+	// stopped nicely, and the stack walk may not be able to complete.
+	if callback != nil && n < max && frame.sp != gp.stktopsp {
+		print("runtime: g", gp.goid, ": frame.sp=", hex(frame.sp), " top=", hex(gp.stktopsp), "\n")
+		print("\tstack=[", hex(gp.stack.lo), "-", hex(gp.stack.hi), "] n=", n, " max=", max, "\n")
+		throw("traceback did not unwind completely")
+	}
+
+	return n
+
+}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -23,7 +23,9 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		v:        v,
 		flags:    flags,
 	}
-	itr.init()
+	if !itr.init() {
+		return 0
+	}
 	return itr.Gentraceback()
 }
 
@@ -46,7 +48,7 @@ type tracebackIterator struct {
 	printing bool
 }
 
-func (itr *tracebackIterator) init() {
+func (itr *tracebackIterator) init() bool {
 	if itr.skip > 0 && itr.callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -123,23 +125,25 @@ func (itr *tracebackIterator) init() {
 		itr.frame.pc = itr.frame.lr
 		itr.frame.lr = 0
 	}
-}
 
-func (itr *tracebackIterator) Gentraceback() int {
-	frame := itr.frame
-
-	f := findfunc(frame.pc)
+	f := findfunc(itr.frame.pc)
 	if !f.valid() {
 		if itr.callback != nil || itr.printing {
-			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(frame.pc), "\n")
-			tracebackHexdump(itr.stack, &frame, 0)
+			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(itr.frame.pc), "\n")
+			tracebackHexdump(itr.stack, &itr.frame, 0)
 		}
 		if itr.callback != nil {
 			throw("unknown pc")
 		}
-		return 0
+		return false
 	}
-	frame.fn = f
+	setFuncInfoNoWB(&itr.frame.fn, f)
+	return true
+}
+
+func (itr *tracebackIterator) Gentraceback() int {
+	frame := itr.frame
+	f := itr.frame.fn
 
 	var cache pcvalueCache
 
@@ -602,4 +606,13 @@ func setSliceNoWB[T any](dst *[]T, src []T) {
 	dstHdr.len = srcHdr.len
 	dstHdr.cap = srcHdr.cap
 	*(*uintptr)(unsafe.Pointer(&dstHdr.array)) = uintptr(srcHdr.array)
+}
+
+// setFuncInfoNoWB performs *dst = src without a write barrier.
+//
+//go:nosplit
+//go:nowritebarrier
+func setFuncInfoNoWB(dst *funcInfo, src funcInfo) {
+	setNoWB(&dst._func, src._func)
+	setNoWB(&dst.datap, src.datap)
 }

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -11,11 +11,19 @@ import (
 )
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
-	var itr tracebackIterator
+	itr := tracebackIterator{}
 	return itr.Gentraceback(pc0, sp0, lr0, gp, skip, pcbuf, max, callback, v, flags)
 }
 
 type tracebackIterator struct {
+	pc0, sp0, lr0 uintptr
+	gp            *g
+	skip          int
+	pcbuf         *uintptr
+	max           int
+	callback      func(*stkframe, unsafe.Pointer) bool
+	v             unsafe.Pointer
+	flags         uint
 }
 
 func (itr *tracebackIterator) Gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -13,23 +13,29 @@ import (
 type tracebackState int
 
 const (
-	tracebackInit tracebackState = iota
-	tracebackPrepareFrame
-	tracebackBufInlineFrame
-	tracebackBufNormalFrame
-	tracebackPostamble
-	tracebackDone
+	stateInit tracebackState = iota
+	statePrepareFrame
+	stateBufInlineFrame
+	stateBufNormalFrame
+	statePostamble
+	stateDone
+	stateError
 )
 
-type tracebackError int
+type tracebackEvent int
 
 const (
-	tracebackNoError tracebackError = iota
-	tracebackOwnStack
-	tracebackUnknownPC
-	tracebackUnexpectedSPWrite
-	tracebackUnexpectedReturnPC
-	tracebackStuck
+	eventOK tracebackEvent = iota
+	eventMaxReached
+	eventNoPCSP
+	eventPCBufInline
+	eventBufNormal
+	eventNoPCBuf
+	eventOwnStack
+	eventUnknownPC
+	eventUnexpectedSPWrite
+	eventUnexpectedReturnPC
+	eventStuck
 )
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
@@ -64,9 +70,9 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	}
 
 	switch itr.Error() {
-	case tracebackOwnStack:
+	case eventOwnStack:
 		throw("gentraceback cannot trace user goroutine on its own stack")
-	case tracebackUnknownPC:
+	case eventUnknownPC:
 		if callback != nil || printing {
 			// TODO(fg) don't access itr state like this?
 			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(itr.frame.pc), "\n")
@@ -76,7 +82,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 			throw("unknown pc")
 		}
 		return 0 // tracebackUnknownPC happens in init()
-	case tracebackUnexpectedSPWrite:
+	case eventUnexpectedSPWrite:
 		if callback != nil && n > 1 {
 			println("traceback: unexpected SPWRITE function", funcname(itr.frame.fn))
 			throw("traceback")
@@ -158,14 +164,14 @@ type tracebackIterator struct {
 	lastFuncID   funcID
 	n            int
 	currentFrame stkframe // frame is already the next frame when Next() returns
-	error        tracebackError
+	event        tracebackEvent
 	inldata      unsafe.Pointer
 	pc           uintptr
 	tracepc      uintptr
 	flr          funcInfo
 }
 
-func (itr *tracebackIterator) init() tracebackError {
+func (itr *tracebackIterator) init() tracebackEvent {
 	// Don't call this "g"; it's too easy get "g" and "gp" confused.
 	if ourg := getg(); ourg == itr.gp && ourg == ourg.m.curg {
 		// The starting sp has been passed in as a uintptr, and the caller may
@@ -181,7 +187,7 @@ func (itr *tracebackIterator) init() tracebackError {
 		// accepts an sp for the current goroutine (typically obtained by
 		// calling getcallersp) must not run on that goroutine's stack but
 		// instead on the g0 stack.
-		return tracebackOwnStack
+		return eventOwnStack
 	}
 	itr.level, _, _ = gotraceback()
 
@@ -240,49 +246,63 @@ func (itr *tracebackIterator) init() tracebackError {
 
 	f := findfunc(itr.frame.pc)
 	if !f.valid() {
-		return tracebackUnknownPC
+		return eventUnknownPC
 	}
 	setFuncInfoNoWB(&itr.frame.fn, f)
 
 	itr.lastFuncID = funcID_normal
 
-	return tracebackNoError
+	return eventOK
 }
 
-func (itr *tracebackIterator) Next() bool {
+func (itr *tracebackIterator) Next() (more bool) {
+loop:
 	for {
 		switch itr.state {
-		case tracebackInit:
-			if itr.error = itr.init(); itr.error != tracebackNoError {
-				itr.state = tracebackDone
-				return false
+		case stateInit:
+			switch itr.event = itr.init(); itr.event {
+			case eventOK:
+				itr.state = statePrepareFrame
+			default:
+				itr.state = stateError
+				break loop
 			}
-			itr.state = tracebackPrepareFrame
-		case tracebackPrepareFrame:
-			itr.state, itr.error = itr.prepareFrame()
-		case tracebackBufInlineFrame:
-			itr.state, itr.error = itr.inlineFrame()
-		case tracebackBufNormalFrame:
-			itr.state, itr.error = itr.normalFrame()
-		case tracebackPostamble:
-			more := itr.next()
+		case statePrepareFrame:
+			switch itr.event = itr.prepareFrame(); itr.event {
+			case eventPCBufInline:
+				itr.state = stateBufInlineFrame
+			case eventBufNormal:
+				itr.state = stateBufNormalFrame
+			case eventNoPCBuf:
+				itr.state = statePostamble
+			default:
+				itr.state = stateError
+				break loop
+			}
+		case stateBufInlineFrame:
+			itr.state, itr.event = itr.inlineFrame()
+		case stateBufNormalFrame:
+			itr.state, itr.event = itr.normalFrame()
+		case statePostamble:
+			more = itr.next()
 			if more {
-				itr.state = tracebackPrepareFrame
+				itr.state = statePrepareFrame
 			} else {
-				itr.state = tracebackDone
+				itr.state = stateDone
 			}
-			return more
-		case tracebackDone:
-			return false
+			break loop
+		case stateDone, stateError:
+			break loop
 		default:
 			throw("bug")
 		}
 	}
+	return more
 }
 
-func (itr *tracebackIterator) prepareFrame() (tracebackState, tracebackError) {
+func (itr *tracebackIterator) prepareFrame() tracebackEvent {
 	if itr.n >= itr.max {
-		return tracebackDone, tracebackNoError
+		return eventMaxReached
 	}
 
 	// Typically:
@@ -295,7 +315,7 @@ func (itr *tracebackIterator) prepareFrame() (tracebackState, tracebackError) {
 	if f.pcsp == 0 {
 		// No frame information, must be external function, like race support.
 		// See golang.org/issue/13568.
-		return tracebackDone, tracebackNoError
+		return eventNoPCSP
 	}
 
 	// Compute function info flags.
@@ -351,7 +371,7 @@ func (itr *tracebackIterator) prepareFrame() (tracebackState, tracebackError) {
 					// instruction opens the frame), therefore no way
 					// to check.
 					flag &^= funcFlag_SPWRITE
-					return tracebackDone, tracebackNoError
+					break
 				}
 				setGNoWB(&itr.gp, itr.gp.m.curg)
 				itr.frame.sp = itr.gp.sched.sp
@@ -389,7 +409,7 @@ func (itr *tracebackIterator) prepareFrame() (tracebackState, tracebackError) {
 		// at the bottom frame of the stack. But farther up the stack we'd better not
 		// find any.
 		if itr.callback {
-			return tracebackDone, tracebackUnexpectedSPWrite
+			return eventUnexpectedSPWrite
 		}
 		itr.frame.lr = 0
 		setFuncInfoNoWB(&itr.flr, funcInfo{})
@@ -521,22 +541,22 @@ func (itr *tracebackIterator) prepareFrame() (tracebackState, tracebackError) {
 		// If there is inlining info, record the inner frames.
 		setUPNoWb(&itr.inldata, funcdata(f, _FUNCDATA_InlTree))
 		if itr.inldata != nil {
-			return tracebackBufInlineFrame, tracebackNoError
+			return eventPCBufInline
 		}
-		return tracebackBufNormalFrame, tracebackNoError
+		return eventBufNormal
 	}
 
-	return tracebackPostamble, tracebackNoError
+	return eventNoPCBuf
 }
 
-func (itr *tracebackIterator) inlineFrame() (tracebackState, tracebackError) {
+func (itr *tracebackIterator) inlineFrame() (tracebackState, tracebackEvent) {
 	f := itr.frame.fn
 
 	inltree := (*[1 << 20]inlinedCall)(itr.inldata)
 
 	ix := pcdatavalue(f, _PCDATA_InlTreeIndex, itr.tracepc, &itr.cache)
 	if ix < 0 {
-		return tracebackBufNormalFrame, tracebackNoError
+		return stateBufNormalFrame, eventOK
 	}
 
 	if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
@@ -552,10 +572,10 @@ func (itr *tracebackIterator) inlineFrame() (tracebackState, tracebackError) {
 	itr.tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 	itr.pc = itr.tracepc + 1
 
-	return tracebackBufInlineFrame, tracebackNoError
+	return stateBufInlineFrame, eventOK
 }
 
-func (itr *tracebackIterator) normalFrame() (tracebackState, tracebackError) {
+func (itr *tracebackIterator) normalFrame() (tracebackState, tracebackEvent) {
 	f := itr.frame.fn
 
 	// Record the main frame.
@@ -570,7 +590,7 @@ func (itr *tracebackIterator) normalFrame() (tracebackState, tracebackError) {
 	itr.lastFuncID = f.funcID
 	itr.n-- // offset n++ below
 
-	return tracebackPostamble, tracebackNoError
+	return statePostamble, eventOK
 }
 
 func (itr *tracebackIterator) next() bool {
@@ -699,8 +719,11 @@ func (itr *tracebackIterator) Frame() *stkframe {
 	return &itr.currentFrame
 }
 
-func (itr *tracebackIterator) Error() tracebackError {
-	return itr.error
+func (itr *tracebackIterator) Error() tracebackEvent {
+	if itr.state == stateError {
+		return itr.event
+	}
+	return 0
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -13,7 +13,7 @@ import (
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	itr := tracebackIterator{
 		pc0: pc0,
-		// sp0:      sp0,
+		sp0: sp0,
 		// lr0:      lr0,
 		// gp:       gp,
 		// skip:     skip,
@@ -23,7 +23,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(sp0, lr0, gp, skip, pcbuf, max, callback, v, flags)
+	return itr.Gentraceback(lr0, gp, skip, pcbuf, max, callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -61,16 +61,16 @@ func (itr *tracebackIterator) Gentraceback(sp0, lr0 uintptr, gp *g, skip int, pc
 	}
 	level, _, _ := gotraceback()
 
-	if itr.pc0 == ^uintptr(0) && sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
+	if itr.pc0 == ^uintptr(0) && itr.sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
 		if gp.syscallsp != 0 {
 			itr.pc0 = gp.syscallpc
-			sp0 = gp.syscallsp
+			itr.sp0 = gp.syscallsp
 			if usesLR {
 				lr0 = 0
 			}
 		} else {
 			itr.pc0 = gp.sched.pc
-			sp0 = gp.sched.sp
+			itr.sp0 = gp.sched.sp
 			if usesLR {
 				lr0 = gp.sched.lr
 			}
@@ -80,7 +80,7 @@ func (itr *tracebackIterator) Gentraceback(sp0, lr0 uintptr, gp *g, skip int, pc
 	nprint := 0
 	var frame stkframe
 	frame.pc = itr.pc0
-	frame.sp = sp0
+	frame.sp = itr.sp0
 	if usesLR {
 		frame.lr = lr0
 	}
@@ -155,7 +155,7 @@ func (itr *tracebackIterator) Gentraceback(sp0, lr0 uintptr, gp *g, skip int, pc
 			// So we don't need to exclude it with the other SP-writing functions.
 			flag &^= funcFlag_SPWRITE
 		}
-		if frame.pc == itr.pc0 && frame.sp == sp0 && itr.pc0 == gp.syscallpc && sp0 == gp.syscallsp {
+		if frame.pc == itr.pc0 && frame.sp == itr.sp0 && itr.pc0 == gp.syscallpc && itr.sp0 == gp.syscallsp {
 			// Some Syscall functions write to SP, but they do so only after
 			// saving the entry PC/SP using entersyscall.
 			// Since we are using the entry PC/SP, the later SP write doesn't matter.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -166,7 +166,6 @@ type tracebackIterator struct {
 	n           int
 	event       tracebackEvent
 	inldata     unsafe.Pointer
-	pc          uintptr
 	tracepc     uintptr
 	flr         funcInfo
 }
@@ -534,9 +533,8 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 	}
 
 	if itr.pcbuf != nil {
-		itr.pc = itr.frame.pc
 		// backup to CALL instruction to read inlining info (same logic as below)
-		itr.tracepc = itr.pc
+		itr.tracepc = itr.frame.pc
 		// Normally, pc is a return address. In that case, we want to look up
 		// file/line information using pc-1, because that is the pc of the
 		// call instruction (more precisely, the last byte of the call instruction).
@@ -548,8 +546,8 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 		// See issue 34123.
 		// The pc can be at function entry when the frame is initialized without
 		// actually running code, like runtime.mstart.
-		if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || itr.pc == f.entry() {
-			itr.pc++
+		if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || itr.frame.pc == f.entry() {
+			itr.frame.pc++
 		} else {
 			itr.tracepc--
 		}
@@ -579,13 +577,13 @@ func (itr *tracebackIterator) inlineFrame() tracebackEvent {
 	} else if itr.skip > 0 {
 		itr.skip--
 	} else if itr.n < itr.max {
-		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.pc
+		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.pc
 		itr.n++
 	}
 	itr.lastFuncID = inltree[ix].funcID
 	// Back up to an instruction in the "caller".
 	itr.tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
-	itr.pc = itr.tracepc + 1
+	itr.frame.pc = itr.tracepc + 1
 
 	return eventPCBufInline
 }
@@ -603,7 +601,7 @@ func (itr *tracebackIterator) normalFrame() tracebackEvent {
 	} else if itr.skip > 0 {
 		itr.skip--
 	} else if itr.n < itr.max {
-		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.pc
+		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.pc
 		itr.n++
 	}
 	itr.lastFuncID = f.funcID

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -63,7 +63,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	var n int
 	for itr.Next() {
 		if callback != nil {
-			if !callback((*stkframe)(noescape(unsafe.Pointer(itr.Frame()))), v) {
+			if !callback((*stkframe)(noescape(unsafe.Pointer(&itr.Frame().stkframe))), v) {
 				return n
 			}
 		}
@@ -77,7 +77,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		if callback != nil || printing {
 			// TODO(fg) don't access itr state like this?
 			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(itr.frame.pc), "\n")
-			tracebackHexdump(itr.stack, &itr.frame, 0)
+			tracebackHexdump(itr.stack, &itr.frame.stkframe, 0)
 		}
 		if callback != nil {
 			throw("unknown pc")
@@ -156,7 +156,7 @@ type tracebackIterator struct {
 	initialized bool
 	level       int32
 	nprint      int
-	frame       stkframe
+	frame       tracebackFrame
 	waspanic    bool
 	cgoCtxt     []uintptr
 	stack       stack
@@ -468,7 +468,7 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 			}
 			if itr.callback || doPrint {
 				print("runtime: g ", itr.gp.goid, ": unexpected return pc for ", funcname(f), " called from ", hex(itr.frame.lr), "\n")
-				tracebackHexdump(itr.stack, &itr.frame, lrPtr)
+				tracebackHexdump(itr.stack, &itr.frame.stkframe, lrPtr)
 			}
 			if itr.callback {
 				throw("unknown caller pc")
@@ -533,6 +533,7 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 	}
 
 	if itr.pcbuf != nil {
+		itr.frame.PC = itr.frame.pc
 		// backup to CALL instruction to read inlining info (same logic as below)
 		itr.tracepc = itr.frame.pc
 		// Normally, pc is a return address. In that case, we want to look up
@@ -547,7 +548,7 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 		// The pc can be at function entry when the frame is initialized without
 		// actually running code, like runtime.mstart.
 		if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || itr.frame.pc == f.entry() {
-			itr.frame.pc++
+			itr.frame.PC++
 		} else {
 			itr.tracepc--
 		}
@@ -577,13 +578,13 @@ func (itr *tracebackIterator) inlineFrame() tracebackEvent {
 	} else if itr.skip > 0 {
 		itr.skip--
 	} else if itr.n < itr.max {
-		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.pc
+		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.PC
 		itr.n++
 	}
 	itr.lastFuncID = inltree[ix].funcID
 	// Back up to an instruction in the "caller".
 	itr.tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
-	itr.frame.pc = itr.tracepc + 1
+	itr.frame.PC = itr.tracepc + 1
 
 	return eventPCBufInline
 }
@@ -601,7 +602,7 @@ func (itr *tracebackIterator) normalFrame() tracebackEvent {
 	} else if itr.skip > 0 {
 		itr.skip--
 	} else if itr.n < itr.max {
-		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.pc
+		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.PC
 		itr.n++
 	}
 	itr.lastFuncID = f.funcID
@@ -705,7 +706,7 @@ func (itr *tracebackIterator) postamble() tracebackEvent {
 	if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
 		// If the next frame is identical to the current frame, we cannot make progress.
 		print("runtime: traceback stuck. pc=", hex(itr.frame.pc), " sp=", hex(itr.frame.sp), "\n")
-		tracebackHexdump(itr.stack, &itr.frame, itr.frame.sp)
+		tracebackHexdump(itr.stack, &itr.frame.stkframe, itr.frame.sp)
 		throw("traceback stuck")
 	}
 
@@ -735,7 +736,7 @@ func (itr *tracebackIterator) postamble() tracebackEvent {
 	return eventMaxReached
 }
 
-func (itr *tracebackIterator) Frame() *stkframe {
+func (itr *tracebackIterator) Frame() *tracebackFrame {
 	return &itr.frame
 }
 
@@ -744,6 +745,13 @@ func (itr *tracebackIterator) Error() tracebackEvent {
 		return itr.event
 	}
 	return 0
+}
+
+// tracebackFrame is a logical stack frame returned by the iterator.
+type tracebackFrame struct {
+	stkframe
+	PC     uintptr
+	FuncID funcID
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -94,7 +94,7 @@ func (itr *tracebackIterator) init() {
 	}
 
 	itr.waspanic = false
-	setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+	setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 	itr.stack = itr.gp.stack
 	itr.printing = itr.pcbuf == nil && itr.callback == nil
 
@@ -199,7 +199,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					frame.lr = itr.gp.sched.lr
 					frame.sp = itr.gp.sched.sp
 					itr.stack = itr.gp.stack
-					setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+					setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 				case funcID_systemstack:
 					// systemstack returns normally, so just follow the
 					// stack transition.
@@ -217,7 +217,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					setGNoWB(&itr.gp, itr.gp.m.curg)
 					frame.sp = itr.gp.sched.sp
 					itr.stack = itr.gp.stack
-					setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
+					setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 					flag &^= funcFlag_SPWRITE
 				}
 			}
@@ -584,10 +584,22 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 }
 
-// setNoWB performs dst = &src without a write barrier.
+// setNoWB performs *dst = src without a write barrier.
 //
 //go:nosplit
 //go:nowritebarrier
-func setNoWB[T any](dst *T, src T) {
-	*(*uintptr)(unsafe.Pointer(dst)) = uintptr(unsafe.Pointer(&src))
+func setNoWB[T any](dst **T, src *T) {
+	*(*uintptr)(unsafe.Pointer(dst)) = uintptr(unsafe.Pointer(src))
+}
+
+// setSliceNoWB performs *dst = src without a write barrier.
+//
+//go:nosplit
+//go:nowritebarrier
+func setSliceNoWB[T any](dst *[]T, src []T) {
+	srcHdr := (*slice)(unsafe.Pointer(&src))
+	dstHdr := (*slice)(unsafe.Pointer(dst))
+	dstHdr.len = srcHdr.len
+	dstHdr.cap = srcHdr.cap
+	*(*uintptr)(unsafe.Pointer(&dstHdr.array)) = uintptr(srcHdr.array)
 }

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -46,6 +46,7 @@ type tracebackIterator struct {
 	cgoCtxt  []uintptr
 	stack    stack
 	printing bool
+	cache    pcvalueCache
 }
 
 func (itr *tracebackIterator) init() bool {
@@ -144,8 +145,6 @@ func (itr *tracebackIterator) init() bool {
 func (itr *tracebackIterator) Gentraceback() int {
 	f := itr.frame.fn
 
-	var cache pcvalueCache
-
 	lastFuncID := funcID_normal
 	n := 0
 	for n < itr.max {
@@ -206,7 +205,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 				case funcID_systemstack:
 					// systemstack returns normally, so just follow the
 					// stack transition.
-					if usesLR && funcspdelta(f, itr.frame.pc, &cache) == 0 {
+					if usesLR && funcspdelta(f, itr.frame.pc, &itr.cache) == 0 {
 						// We're at the function prologue and the stack
 						// switch hasn't happened, or epilogue where we're
 						// about to return. Just unwind normally.
@@ -224,7 +223,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					flag &^= funcFlag_SPWRITE
 				}
 			}
-			itr.frame.fp = itr.frame.sp + uintptr(funcspdelta(f, itr.frame.pc, &cache))
+			itr.frame.fp = itr.frame.sp + uintptr(funcspdelta(f, itr.frame.pc, &itr.cache))
 			if !usesLR {
 				// On x86, call instruction pushes return PC before entering new function.
 				itr.frame.fp += goarch.PtrSize
@@ -383,7 +382,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
 				inltree := (*[1 << 20]inlinedCall)(inldata)
 				for {
-					ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, &cache)
+					ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, &itr.cache)
 					if ix < 0 {
 						break
 					}
@@ -527,7 +526,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			setFuncInfoNoWB(&itr.frame.fn, f)
 			if !f.valid() {
 				itr.frame.pc = x
-			} else if funcspdelta(f, itr.frame.pc, &cache) == 0 {
+			} else if funcspdelta(f, itr.frame.pc, &itr.cache) == 0 {
 				itr.frame.lr = x
 			}
 		}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -14,7 +14,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	itr := tracebackIterator{
 		pc0: pc0,
 		sp0: sp0,
-		// lr0:      lr0,
+		lr0: lr0,
 		// gp:       gp,
 		// skip:     skip,
 		// pcbuf:    pcbuf,
@@ -23,7 +23,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(lr0, gp, skip, pcbuf, max, callback, v, flags)
+	return itr.Gentraceback(gp, skip, pcbuf, max, callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -66,13 +66,13 @@ func (itr *tracebackIterator) Gentraceback(lr0 uintptr, gp *g, skip int, pcbuf *
 			itr.pc0 = gp.syscallpc
 			itr.sp0 = gp.syscallsp
 			if usesLR {
-				lr0 = 0
+				itr.lr0 = 0
 			}
 		} else {
 			itr.pc0 = gp.sched.pc
 			itr.sp0 = gp.sched.sp
 			if usesLR {
-				lr0 = gp.sched.lr
+				itr.lr0 = gp.sched.lr
 			}
 		}
 	}
@@ -82,7 +82,7 @@ func (itr *tracebackIterator) Gentraceback(lr0 uintptr, gp *g, skip int, pcbuf *
 	frame.pc = itr.pc0
 	frame.sp = itr.sp0
 	if usesLR {
-		frame.lr = lr0
+		frame.lr = itr.lr0
 	}
 	waspanic := false
 	cgoCtxt := gp.cgoCtxt

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -20,10 +20,10 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		pcbuf:    pcbuf,
 		max:      max,
 		callback: callback,
-		// v:        v,
+		v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(v, flags)
+	return itr.Gentraceback(flags)
 }
 
 type tracebackIterator struct {
@@ -37,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(flags uint) int {
 	if itr.skip > 0 && itr.callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -337,7 +337,7 @@ func (itr *tracebackIterator) Gentraceback(v unsafe.Pointer, flags uint) int {
 		}
 
 		if itr.callback != nil {
-			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&frame))), v) {
+			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&frame))), noescape(itr.v)) {
 				return n
 			}
 		}

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -97,20 +97,16 @@ func (itr *tracebackIterator) init() {
 	setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 	itr.stack = itr.gp.stack
 	itr.printing = itr.pcbuf == nil && itr.callback == nil
-}
-
-func (itr *tracebackIterator) Gentraceback() int {
-	frame := itr.frame
 
 	// If the PC is zero, it's likely a nil function call.
 	// Start in the caller's frame.
-	if frame.pc == 0 {
+	if itr.frame.pc == 0 {
 		if usesLR {
-			frame.pc = *(*uintptr)(unsafe.Pointer(frame.sp))
-			frame.lr = 0
+			itr.frame.pc = *(*uintptr)(unsafe.Pointer(itr.frame.sp))
+			itr.frame.lr = 0
 		} else {
-			frame.pc = uintptr(*(*uintptr)(unsafe.Pointer(frame.sp)))
-			frame.sp += goarch.PtrSize
+			itr.frame.pc = uintptr(*(*uintptr)(unsafe.Pointer(itr.frame.sp)))
+			itr.frame.sp += goarch.PtrSize
 		}
 	}
 
@@ -118,15 +114,19 @@ func (itr *tracebackIterator) Gentraceback() int {
 	// arm < 7. See runtime/internal/atomic/sys_linux_arm.s.
 	//
 	// Start in the caller's frame.
-	if GOARCH == "arm" && goarm < 7 && GOOS == "linux" && frame.pc&0xffff0000 == 0xffff0000 {
+	if GOARCH == "arm" && goarm < 7 && GOOS == "linux" && itr.frame.pc&0xffff0000 == 0xffff0000 {
 		// Note that the calls are simple BL without pushing the return
 		// address, so we use LR directly.
 		//
 		// The kernel helpers are frameless leaf functions, so SP and
 		// LR are not touched.
-		frame.pc = frame.lr
-		frame.lr = 0
+		itr.frame.pc = itr.frame.lr
+		itr.frame.lr = 0
 	}
+}
+
+func (itr *tracebackIterator) Gentraceback() int {
+	frame := itr.frame
 
 	f := findfunc(frame.pc)
 	if !f.valid() {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -37,9 +37,10 @@ type tracebackIterator struct {
 	v             unsafe.Pointer
 	flags         uint
 
-	level  int32
-	nprint int
-	frame  stkframe
+	level    int32
+	nprint   int
+	frame    stkframe
+	waspanic bool
 }
 
 func (itr *tracebackIterator) init() {
@@ -88,12 +89,13 @@ func (itr *tracebackIterator) init() {
 	if usesLR {
 		itr.frame.lr = itr.lr0
 	}
+
+	itr.waspanic = false
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
 	frame := itr.frame
 
-	waspanic := false
 	cgoCtxt := itr.gp.cgoCtxt
 	stack := itr.gp.stack
 	printing := itr.pcbuf == nil && itr.callback == nil
@@ -328,7 +330,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 		// deferproc a second time (if the corresponding deferred func recovers).
 		// In the latter case, use a deferreturn call site as the continuation pc.
 		frame.continpc = frame.pc
-		if waspanic {
+		if itr.waspanic {
 			if frame.fn.deferreturn != 0 {
 				frame.continpc = frame.fn.entry() + uintptr(frame.fn.deferreturn) + 1
 				// Note: this may perhaps keep return variables alive longer than
@@ -366,7 +368,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 			// See issue 34123.
 			// The pc can be at function entry when the frame is initialized without
 			// actually running code, like runtime.mstart.
-			if (n == 0 && itr.flags&_TraceTrap != 0) || waspanic || pc == f.entry() {
+			if (n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || pc == f.entry() {
 				pc++
 			} else {
 				tracepc--
@@ -417,7 +419,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 			// backup to CALL instruction to read inlining info (same logic as below)
 			tracepc := frame.pc
-			if (n > 0 || itr.flags&_TraceTrap == 0) && frame.pc > f.entry() && !waspanic {
+			if (n > 0 || itr.flags&_TraceTrap == 0) && frame.pc > f.entry() && !itr.waspanic {
 				tracepc--
 			}
 			// If there is inlining info, print the inner frames.
@@ -489,8 +491,8 @@ func (itr *tracebackIterator) Gentraceback() int {
 			}
 		}
 
-		waspanic = f.funcID == funcID_sigpanic
-		injectedCall := waspanic || f.funcID == funcID_asyncPreempt || f.funcID == funcID_debugCallV2
+		itr.waspanic = f.funcID == funcID_sigpanic
+		injectedCall := itr.waspanic || f.funcID == funcID_asyncPreempt || f.funcID == funcID_debugCallV2
 
 		// Do not unwind past the bottom of the stack.
 		if !flr.valid() {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -11,8 +11,19 @@ import (
 )
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
-	itr := tracebackIterator{}
-	return itr.Gentraceback(pc0, sp0, lr0, gp, skip, pcbuf, max, callback, v, flags)
+	itr := tracebackIterator{
+		pc0: pc0,
+		// sp0:      sp0,
+		// lr0:      lr0,
+		// gp:       gp,
+		// skip:     skip,
+		// pcbuf:    pcbuf,
+		// max:      max,
+		// callback: callback,
+		// v:        v,
+		// flags:    flags,
+	}
+	return itr.Gentraceback(sp0, lr0, gp, skip, pcbuf, max, callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -26,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -50,15 +61,15 @@ func (itr *tracebackIterator) Gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip in
 	}
 	level, _, _ := gotraceback()
 
-	if pc0 == ^uintptr(0) && sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
+	if itr.pc0 == ^uintptr(0) && sp0 == ^uintptr(0) { // Signal to fetch saved values from gp.
 		if gp.syscallsp != 0 {
-			pc0 = gp.syscallpc
+			itr.pc0 = gp.syscallpc
 			sp0 = gp.syscallsp
 			if usesLR {
 				lr0 = 0
 			}
 		} else {
-			pc0 = gp.sched.pc
+			itr.pc0 = gp.sched.pc
 			sp0 = gp.sched.sp
 			if usesLR {
 				lr0 = gp.sched.lr
@@ -68,7 +79,7 @@ func (itr *tracebackIterator) Gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip in
 
 	nprint := 0
 	var frame stkframe
-	frame.pc = pc0
+	frame.pc = itr.pc0
 	frame.sp = sp0
 	if usesLR {
 		frame.lr = lr0
@@ -144,7 +155,7 @@ func (itr *tracebackIterator) Gentraceback(pc0, sp0, lr0 uintptr, gp *g, skip in
 			// So we don't need to exclude it with the other SP-writing functions.
 			flag &^= funcFlag_SPWRITE
 		}
-		if frame.pc == pc0 && frame.sp == sp0 && pc0 == gp.syscallpc && sp0 == gp.syscallsp {
+		if frame.pc == itr.pc0 && frame.sp == sp0 && itr.pc0 == gp.syscallpc && sp0 == gp.syscallsp {
 			// Some Syscall functions write to SP, but they do so only after
 			// saving the entry PC/SP using entersyscall.
 			// Since we are using the entry PC/SP, the later SP write doesn't matter.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -11,6 +11,12 @@ import (
 )
 
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+	if callback != nil && pcbuf != nil {
+		throw("unexpected: callback and pcbuf set")
+	} else if skip > 0 && callback != nil {
+		throw("gentraceback callback cannot be used with non-zero skip")
+	}
+
 	itr := tracebackIterator{
 		pc0:      pc0,
 		sp0:      sp0,
@@ -21,6 +27,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		max:      max,
 		callback: *(*func(*stkframe, unsafe.Pointer) bool)(noescape(unsafe.Pointer(&callback))),
 		flags:    flags,
+		printing: callback == nil && pcbuf == nil,
 	}
 	if !itr.init() {
 		return 0
@@ -78,7 +85,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	// At other times, such as when gathering a stack for a profiling signal
 	// or when printing a traceback during a crash, everything may not be
 	// stopped nicely, and the stack walk may not be able to complete.
-	if itr.callback != nil && itr.n < itr.max && itr.frame.sp != itr.gp.stktopsp {
+	if callback != nil && itr.n < itr.max && itr.frame.sp != itr.gp.stktopsp {
 		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(itr.frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
 		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", itr.n, " max=", itr.max, "\n")
 		throw("traceback did not unwind completely")
@@ -110,14 +117,6 @@ type tracebackIterator struct {
 }
 
 func (itr *tracebackIterator) init() bool {
-	if itr.callback != nil && itr.pcbuf != nil {
-		throw("unexpected: callback and pcbuf set")
-	}
-
-	if itr.skip > 0 && itr.callback != nil {
-		throw("gentraceback callback cannot be used with non-zero skip")
-	}
-
 	// Don't call this "g"; it's too easy get "g" and "gp" confused.
 	if ourg := getg(); ourg == itr.gp && ourg == ourg.m.curg {
 		// The starting sp has been passed in as a uintptr, and the caller may
@@ -163,7 +162,6 @@ func (itr *tracebackIterator) init() bool {
 	itr.waspanic = false
 	setSliceNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 	itr.stack = itr.gp.stack
-	itr.printing = itr.pcbuf == nil && itr.callback == nil
 
 	// If the PC is zero, it's likely a nil function call.
 	// Start in the caller's frame.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -152,24 +152,23 @@ type tracebackIterator struct {
 	callback      bool
 	flags         uint
 
-	state        tracebackState
-	initialized  bool
-	level        int32
-	nprint       int
-	frame        stkframe
-	waspanic     bool
-	cgoCtxt      []uintptr
-	stack        stack
-	printing     bool
-	cache        pcvalueCache
-	lastFuncID   funcID
-	n            int
-	currentFrame stkframe // frame is already the next frame when Next() returns
-	event        tracebackEvent
-	inldata      unsafe.Pointer
-	pc           uintptr
-	tracepc      uintptr
-	flr          funcInfo
+	state       tracebackState
+	initialized bool
+	level       int32
+	nprint      int
+	frame       stkframe
+	waspanic    bool
+	cgoCtxt     []uintptr
+	stack       stack
+	printing    bool
+	cache       pcvalueCache
+	lastFuncID  funcID
+	n           int
+	event       tracebackEvent
+	inldata     unsafe.Pointer
+	pc          uintptr
+	tracepc     uintptr
+	flr         funcInfo
 }
 
 func (itr *tracebackIterator) init() tracebackEvent {
@@ -534,16 +533,6 @@ func (itr *tracebackIterator) preamble() tracebackEvent {
 		}
 	}
 
-	// TODO(fg) remove this hack
-	setFuncInfoNoWB(&itr.currentFrame.fn, itr.frame.fn)
-	itr.currentFrame.pc = itr.frame.pc
-	itr.currentFrame.continpc = itr.frame.continpc
-	itr.currentFrame.lr = itr.frame.lr
-	itr.currentFrame.sp = itr.frame.sp
-	itr.currentFrame.fp = itr.frame.fp
-	itr.currentFrame.varp = itr.frame.varp
-	itr.currentFrame.argp = itr.frame.argp
-
 	if itr.pcbuf != nil {
 		itr.pc = itr.frame.pc
 		// backup to CALL instruction to read inlining info (same logic as below)
@@ -749,7 +738,7 @@ func (itr *tracebackIterator) postamble() tracebackEvent {
 }
 
 func (itr *tracebackIterator) Frame() *stkframe {
-	return &itr.currentFrame
+	return &itr.frame
 }
 
 func (itr *tracebackIterator) Error() tracebackEvent {

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -41,6 +41,7 @@ type tracebackIterator struct {
 	nprint   int
 	frame    stkframe
 	waspanic bool
+	cgoCtxt  []uintptr
 }
 
 func (itr *tracebackIterator) init() {
@@ -91,12 +92,12 @@ func (itr *tracebackIterator) init() {
 	}
 
 	itr.waspanic = false
+	setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
 	frame := itr.frame
 
-	cgoCtxt := itr.gp.cgoCtxt
 	stack := itr.gp.stack
 	printing := itr.pcbuf == nil && itr.callback == nil
 
@@ -197,7 +198,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					frame.lr = itr.gp.sched.lr
 					frame.sp = itr.gp.sched.sp
 					stack = itr.gp.stack
-					cgoCtxt = itr.gp.cgoCtxt
+					setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 				case funcID_systemstack:
 					// systemstack returns normally, so just follow the
 					// stack transition.
@@ -215,7 +216,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					setGNoWB(&itr.gp, itr.gp.m.curg)
 					frame.sp = itr.gp.sched.sp
 					stack = itr.gp.stack
-					cgoCtxt = itr.gp.cgoCtxt
+					setNoWB(&itr.cgoCtxt, itr.gp.cgoCtxt)
 					flag &^= funcFlag_SPWRITE
 				}
 			}
@@ -479,9 +480,9 @@ func (itr *tracebackIterator) Gentraceback() int {
 		}
 		n++
 
-		if f.funcID == funcID_cgocallback && len(cgoCtxt) > 0 {
-			ctxt := cgoCtxt[len(cgoCtxt)-1]
-			cgoCtxt = cgoCtxt[:len(cgoCtxt)-1]
+		if f.funcID == funcID_cgocallback && len(itr.cgoCtxt) > 0 {
+			ctxt := itr.cgoCtxt[len(itr.cgoCtxt)-1]
+			itr.cgoCtxt = itr.cgoCtxt[:len(itr.cgoCtxt)-1]
 
 			// skip only applies to Go frames.
 			// callback != nil only used when we only care
@@ -580,4 +581,12 @@ func (itr *tracebackIterator) Gentraceback() int {
 
 	return n
 
+}
+
+// setNoWB performs dst = &src without a write barrier.
+//
+//go:nosplit
+//go:nowritebarrier
+func setNoWB[T any](dst *T, src T) {
+	*(*uintptr)(unsafe.Pointer(dst)) = uintptr(unsafe.Pointer(&src))
 }

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -18,12 +18,12 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		gp:    gp,
 		skip:  skip,
 		pcbuf: pcbuf,
-		// max:      max,
+		max:   max,
 		// callback: callback,
 		// v:        v,
 		// flags:    flags,
 	}
-	return itr.Gentraceback(max, callback, v, flags)
+	return itr.Gentraceback(callback, v, flags)
 }
 
 type tracebackIterator struct {
@@ -37,7 +37,7 @@ type tracebackIterator struct {
 	flags         uint
 }
 
-func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
+func (itr *tracebackIterator) Gentraceback(callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if itr.skip > 0 && callback != nil {
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
@@ -132,7 +132,7 @@ func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, uns
 
 	lastFuncID := funcID_normal
 	n := 0
-	for n < max {
+	for n < itr.max {
 		// Typically:
 		//	pc is the PC of the running function.
 		//	sp is the stack pointer at that program counter.
@@ -375,7 +375,7 @@ func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, uns
 						// ignore wrappers
 					} else if itr.skip > 0 {
 						itr.skip--
-					} else if n < max {
+					} else if n < itr.max {
 						(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
 						n++
 					}
@@ -390,7 +390,7 @@ func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, uns
 				// Ignore wrapper functions (except when they trigger panics).
 			} else if itr.skip > 0 {
 				itr.skip--
-			} else if n < max {
+			} else if n < itr.max {
 				(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[n] = pc
 				n++
 			}
@@ -476,7 +476,7 @@ func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, uns
 			// callback != nil only used when we only care
 			// about Go frames.
 			if itr.skip == 0 && callback == nil {
-				n = tracebackCgoContext(itr.pcbuf, printing, ctxt, n, max)
+				n = tracebackCgoContext(itr.pcbuf, printing, ctxt, n, itr.max)
 			}
 		}
 
@@ -561,9 +561,9 @@ func (itr *tracebackIterator) Gentraceback(max int, callback func(*stkframe, uns
 	// At other times, such as when gathering a stack for a profiling signal
 	// or when printing a traceback during a crash, everything may not be
 	// stopped nicely, and the stack walk may not be able to complete.
-	if callback != nil && n < max && frame.sp != itr.gp.stktopsp {
+	if callback != nil && n < itr.max && frame.sp != itr.gp.stktopsp {
 		print("runtime: g", itr.gp.goid, ": frame.sp=", hex(frame.sp), " top=", hex(itr.gp.stktopsp), "\n")
-		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", n, " max=", max, "\n")
+		print("\tstack=[", hex(itr.gp.stack.lo), "-", hex(itr.gp.stack.hi), "] n=", n, " max=", itr.max, "\n")
 		throw("traceback did not unwind completely")
 	}
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -25,7 +25,9 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	}
 	if !itr.init() {
 		return 0
-	} else if !itr.Gentraceback() {
+	}
+	itr.Gentraceback()
+	if itr.callbackAbort {
 		return itr.n
 	}
 
@@ -92,16 +94,17 @@ type tracebackIterator struct {
 	v             unsafe.Pointer
 	flags         uint
 
-	level      int32
-	nprint     int
-	frame      stkframe
-	waspanic   bool
-	cgoCtxt    []uintptr
-	stack      stack
-	printing   bool
-	cache      pcvalueCache
-	lastFuncID funcID
-	n          int
+	level         int32
+	nprint        int
+	frame         stkframe
+	waspanic      bool
+	cgoCtxt       []uintptr
+	stack         stack
+	printing      bool
+	cache         pcvalueCache
+	lastFuncID    funcID
+	n             int
+	callbackAbort bool
 }
 
 func (itr *tracebackIterator) init() bool {
@@ -200,7 +203,7 @@ func (itr *tracebackIterator) init() bool {
 	return true
 }
 
-func (itr *tracebackIterator) Gentraceback() bool {
+func (itr *tracebackIterator) Gentraceback() {
 	f := itr.frame.fn
 	for itr.n < itr.max {
 		// Typically:
@@ -408,7 +411,8 @@ func (itr *tracebackIterator) Gentraceback() bool {
 
 		if itr.callback != nil {
 			if !itr.callback((*stkframe)(noescape(unsafe.Pointer(&itr.frame))), noescape(itr.v)) {
-				return false
+				itr.callbackAbort = true
+				return
 			}
 		}
 
@@ -586,7 +590,6 @@ func (itr *tracebackIterator) Gentraceback() bool {
 			}
 		}
 	}
-	return true
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -14,7 +14,10 @@ type tracebackState int
 
 const (
 	tracebackInit tracebackState = iota
-	tracebackNext
+	tracebackPrepareFrame
+	tracebackBufInlineFrame
+	tracebackBufNormalFrame
+	tracebackPostamble
 	tracebackDone
 )
 
@@ -156,6 +159,10 @@ type tracebackIterator struct {
 	n            int
 	currentFrame stkframe // frame is already the next frame when Next() returns
 	error        tracebackError
+	inldata      unsafe.Pointer
+	pc           uintptr
+	tracepc      uintptr
+	flr          funcInfo
 }
 
 func (itr *tracebackIterator) init() tracebackError {
@@ -245,30 +252,37 @@ func (itr *tracebackIterator) init() tracebackError {
 func (itr *tracebackIterator) Next() bool {
 	for {
 		switch itr.state {
-		case tracebackDone:
-			return false
 		case tracebackInit:
 			if itr.error = itr.init(); itr.error != tracebackNoError {
 				itr.state = tracebackDone
 				return false
 			}
-			itr.state = tracebackNext
-		case tracebackNext:
-			var more bool
-			more, itr.error = itr.next()
-			if !more || itr.error != tracebackNoError {
+			itr.state = tracebackPrepareFrame
+		case tracebackPrepareFrame:
+			itr.state, itr.error = itr.prepareFrame()
+		case tracebackBufInlineFrame:
+			itr.state, itr.error = itr.inlineFrame()
+		case tracebackBufNormalFrame:
+			itr.state, itr.error = itr.normalFrame()
+		case tracebackPostamble:
+			more := itr.next()
+			if more {
+				itr.state = tracebackPrepareFrame
+			} else {
 				itr.state = tracebackDone
 			}
 			return more
+		case tracebackDone:
+			return false
 		default:
 			throw("bug")
 		}
 	}
 }
 
-func (itr *tracebackIterator) next() (bool, tracebackError) {
+func (itr *tracebackIterator) prepareFrame() (tracebackState, tracebackError) {
 	if itr.n >= itr.max {
-		return false, tracebackNoError
+		return tracebackDone, tracebackNoError
 	}
 
 	// Typically:
@@ -281,7 +295,7 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 	if f.pcsp == 0 {
 		// No frame information, must be external function, like race support.
 		// See golang.org/issue/13568.
-		return false, tracebackNoError
+		return tracebackDone, tracebackNoError
 	}
 
 	// Compute function info flags.
@@ -337,7 +351,7 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 					// instruction opens the frame), therefore no way
 					// to check.
 					flag &^= funcFlag_SPWRITE
-					return false, tracebackNoError
+					return tracebackDone, tracebackNoError
 				}
 				setGNoWB(&itr.gp, itr.gp.m.curg)
 				itr.frame.sp = itr.gp.sched.sp
@@ -352,11 +366,10 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 			itr.frame.fp += goarch.PtrSize
 		}
 	}
-	var flr funcInfo
 	if flag&funcFlag_TOPFRAME != 0 {
 		// This function marks the top of the stack. Stop the traceback.
 		itr.frame.lr = 0
-		flr = funcInfo{}
+		setFuncInfoNoWB(&itr.flr, funcInfo{})
 	} else if flag&funcFlag_SPWRITE != 0 && (!itr.callback || itr.n > 0) {
 		// The function we are in does a write to SP that we don't know
 		// how to encode in the spdelta table. Examples include context
@@ -376,10 +389,10 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 		// at the bottom frame of the stack. But farther up the stack we'd better not
 		// find any.
 		if itr.callback {
-			return false, tracebackUnexpectedSPWrite
+			return tracebackDone, tracebackUnexpectedSPWrite
 		}
 		itr.frame.lr = 0
-		flr = funcInfo{}
+		setFuncInfoNoWB(&itr.flr, funcInfo{})
 	} else {
 		var lrPtr uintptr
 		if usesLR {
@@ -393,8 +406,9 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 				itr.frame.lr = uintptr(*(*uintptr)(unsafe.Pointer(lrPtr)))
 			}
 		}
-		flr = findfunc(itr.frame.lr)
-		if !flr.valid() {
+
+		setFuncInfoNoWB(&itr.flr, findfunc(itr.frame.lr))
+		if !itr.flr.valid() {
 			// This happens if you get a profiling interrupt at just the wrong time.
 			// In that context it is okay to stop early.
 			// But if callback is set, we're doing a garbage collection and must
@@ -484,9 +498,9 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 	itr.currentFrame.argp = itr.frame.argp
 
 	if itr.pcbuf != nil {
-		pc := itr.frame.pc
+		itr.pc = itr.frame.pc
 		// backup to CALL instruction to read inlining info (same logic as below)
-		tracepc := pc
+		itr.tracepc = itr.pc
 		// Normally, pc is a return address. In that case, we want to look up
 		// file/line information using pc-1, because that is the pc of the
 		// call instruction (more precisely, the last byte of the call instruction).
@@ -498,47 +512,69 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 		// See issue 34123.
 		// The pc can be at function entry when the frame is initialized without
 		// actually running code, like runtime.mstart.
-		if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || pc == f.entry() {
-			pc++
+		if (itr.n == 0 && itr.flags&_TraceTrap != 0) || itr.waspanic || itr.pc == f.entry() {
+			itr.pc++
 		} else {
-			tracepc--
+			itr.tracepc--
 		}
 
 		// If there is inlining info, record the inner frames.
-		if inldata := funcdata(f, _FUNCDATA_InlTree); inldata != nil {
-			inltree := (*[1 << 20]inlinedCall)(inldata)
-			for {
-				ix := pcdatavalue(f, _PCDATA_InlTreeIndex, tracepc, &itr.cache)
-				if ix < 0 {
-					break
-				}
-				if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
-					// ignore wrappers
-				} else if itr.skip > 0 {
-					itr.skip--
-				} else if itr.n < itr.max {
-					(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
-					itr.n++
-				}
-				itr.lastFuncID = inltree[ix].funcID
-				// Back up to an instruction in the "caller".
-				tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
-				pc = tracepc + 1
-			}
+		setUPNoWb(&itr.inldata, funcdata(f, _FUNCDATA_InlTree))
+		if itr.inldata != nil {
+			return tracebackBufInlineFrame, tracebackNoError
 		}
-		// Record the main frame.
-		if f.funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
-			// Ignore wrapper functions (except when they trigger panics).
-		} else if itr.skip > 0 {
-			itr.skip--
-		} else if itr.n < itr.max {
-			(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = pc
-			itr.n++
-		}
-		itr.lastFuncID = f.funcID
-		itr.n-- // offset n++ below
+		return tracebackBufNormalFrame, tracebackNoError
 	}
 
+	return tracebackPostamble, tracebackNoError
+}
+
+func (itr *tracebackIterator) inlineFrame() (tracebackState, tracebackError) {
+	f := itr.frame.fn
+
+	inltree := (*[1 << 20]inlinedCall)(itr.inldata)
+
+	ix := pcdatavalue(f, _PCDATA_InlTreeIndex, itr.tracepc, &itr.cache)
+	if ix < 0 {
+		return tracebackBufNormalFrame, tracebackNoError
+	}
+
+	if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
+		// ignore wrappers
+	} else if itr.skip > 0 {
+		itr.skip--
+	} else if itr.n < itr.max {
+		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.pc
+		itr.n++
+	}
+	itr.lastFuncID = inltree[ix].funcID
+	// Back up to an instruction in the "caller".
+	itr.tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
+	itr.pc = itr.tracepc + 1
+
+	return tracebackBufInlineFrame, tracebackNoError
+}
+
+func (itr *tracebackIterator) normalFrame() (tracebackState, tracebackError) {
+	f := itr.frame.fn
+
+	// Record the main frame.
+	if f.funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
+		// Ignore wrapper functions (except when they trigger panics).
+	} else if itr.skip > 0 {
+		itr.skip--
+	} else if itr.n < itr.max {
+		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.pc
+		itr.n++
+	}
+	itr.lastFuncID = f.funcID
+	itr.n-- // offset n++ below
+
+	return tracebackPostamble, tracebackNoError
+}
+
+func (itr *tracebackIterator) next() bool {
+	f := itr.frame.fn
 	if itr.printing {
 		// assume skip=0 for printing.
 		//
@@ -625,8 +661,8 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 	injectedCall := itr.waspanic || f.funcID == funcID_asyncPreempt || f.funcID == funcID_debugCallV2
 
 	// Do not unwind past the bottom of the stack.
-	if !flr.valid() {
-		return false, tracebackNoError
+	if !itr.flr.valid() {
+		return false
 	}
 
 	if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
@@ -637,7 +673,7 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 	}
 
 	// Unwind to next frame.
-	setFuncInfoNoWB(&itr.frame.fn, flr)
+	setFuncInfoNoWB(&itr.frame.fn, itr.flr)
 	itr.frame.pc = itr.frame.lr
 	itr.frame.lr = 0
 	itr.frame.sp = itr.frame.fp
@@ -656,7 +692,7 @@ func (itr *tracebackIterator) next() (bool, tracebackError) {
 			itr.frame.lr = x
 		}
 	}
-	return itr.n < itr.max, tracebackNoError
+	return itr.n < itr.max
 }
 
 func (itr *tracebackIterator) Frame() *stkframe {
@@ -694,4 +730,12 @@ func setSliceNoWB[T any](dst *[]T, src []T) {
 func setFuncInfoNoWB(dst *funcInfo, src funcInfo) {
 	setNoWB(&dst._func, src._func)
 	setNoWB(&dst.datap, src.datap)
+}
+
+// setUPNoWb performs *dst = src without a write barrier.
+//
+//go:nosplit
+//go:nowritebarrier
+func setUPNoWb(dst *unsafe.Pointer, src unsafe.Pointer) {
+	*(*uintptr)(unsafe.Pointer(dst)) = uintptr(src)
 }

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -573,7 +573,9 @@ func (itr *tracebackIterator) inlineFrame() tracebackEvent {
 		return eventBufNormal
 	}
 
-	if inltree[ix].funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
+	itr.frame.FuncID = inltree[ix].funcID
+
+	if itr.frame.FuncID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
 		// ignore wrappers
 	} else if itr.skip > 0 {
 		itr.skip--
@@ -581,7 +583,7 @@ func (itr *tracebackIterator) inlineFrame() tracebackEvent {
 		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.PC
 		itr.n++
 	}
-	itr.lastFuncID = inltree[ix].funcID
+	itr.lastFuncID = itr.frame.FuncID
 	// Back up to an instruction in the "caller".
 	itr.tracepc = itr.frame.fn.entry() + uintptr(inltree[ix].parentPc)
 	itr.frame.PC = itr.tracepc + 1
@@ -595,9 +597,10 @@ func (itr *tracebackIterator) normalFrame() tracebackEvent {
 	}
 
 	f := itr.frame.fn
+	itr.frame.FuncID = f.funcID
 
 	// Record the main frame.
-	if f.funcID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
+	if itr.frame.FuncID == funcID_wrapper && elideWrapperCalling(itr.lastFuncID) {
 		// Ignore wrapper functions (except when they trigger panics).
 	} else if itr.skip > 0 {
 		itr.skip--
@@ -605,7 +608,7 @@ func (itr *tracebackIterator) normalFrame() tracebackEvent {
 		(*[1 << 20]uintptr)(unsafe.Pointer(itr.pcbuf))[itr.n] = itr.frame.PC
 		itr.n++
 	}
-	itr.lastFuncID = f.funcID
+	itr.lastFuncID = itr.frame.FuncID
 	itr.n-- // offset n++ below
 
 	return eventOK

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -37,7 +37,8 @@ type tracebackIterator struct {
 	v             unsafe.Pointer
 	flags         uint
 
-	level int32
+	level  int32
+	nprint int
 }
 
 func (itr *tracebackIterator) init() {
@@ -79,11 +80,10 @@ func (itr *tracebackIterator) init() {
 			}
 		}
 	}
+	itr.nprint = 0
 }
 
 func (itr *tracebackIterator) Gentraceback() int {
-
-	nprint := 0
 	var frame stkframe
 	frame.pc = itr.pc0
 	frame.sp = itr.sp0
@@ -434,19 +434,19 @@ func (itr *tracebackIterator) Gentraceback() int {
 					inlFunc.funcID = inltree[ix].funcID
 					inlFunc.startLine = inltree[ix].startLine
 
-					if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, nprint == 0, inlFuncInfo.funcID, lastFuncID) {
+					if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(inlFuncInfo, itr.gp, itr.nprint == 0, inlFuncInfo.funcID, lastFuncID) {
 						name := funcname(inlFuncInfo)
 						file, line := funcline(f, tracepc)
 						print(name, "(...)\n")
 						print("\t", file, ":", line, "\n")
-						nprint++
+						itr.nprint++
 					}
 					lastFuncID = inltree[ix].funcID
 					// Back up to an instruction in the "caller".
 					tracepc = frame.fn.entry() + uintptr(inltree[ix].parentPc)
 				}
 			}
-			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, nprint == 0, f.funcID, lastFuncID) {
+			if (itr.flags&_TraceRuntimeFrames) != 0 || showframe(f, itr.gp, itr.nprint == 0, f.funcID, lastFuncID) {
 				// Print during crash.
 				//	main(0x1, 0x2, 0x3)
 				//		/home/rsc/go/src/runtime/x.go:23 +0xf
@@ -468,7 +468,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 					print(" fp=", hex(frame.fp), " sp=", hex(frame.sp), " pc=", hex(frame.pc))
 				}
 				print("\n")
-				nprint++
+				itr.nprint++
 			}
 			lastFuncID = f.funcID
 		}
@@ -524,7 +524,7 @@ func (itr *tracebackIterator) Gentraceback() int {
 	}
 
 	if printing {
-		n = nprint
+		n = itr.nprint
 	}
 
 	// Note that panic != nil is okay here: there can be leftover panics,

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -14,6 +14,7 @@ type tracebackError int
 
 const (
 	tracebackOK tracebackError = iota
+	tracebackOwnStack
 	tracebackUnknownPC
 	tracebackUnexpectedReturnPC
 	tracebackStuck
@@ -49,6 +50,8 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 	}
 
 	switch itr.Error() {
+	case tracebackOwnStack:
+		throw("gentraceback cannot trace user goroutine on its own stack")
 	case tracebackUnknownPC:
 		if callback != nil || printing {
 			// TODO(fg) don't access itr state like this?
@@ -154,7 +157,8 @@ func (itr *tracebackIterator) init() bool {
 		// accepts an sp for the current goroutine (typically obtained by
 		// calling getcallersp) must not run on that goroutine's stack but
 		// instead on the g0 stack.
-		throw("gentraceback cannot trace user goroutine on its own stack")
+		itr.error = tracebackOwnStack
+		return false
 	}
 	itr.level, _, _ = gotraceback()
 

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -10,6 +10,15 @@ import (
 	"unsafe"
 )
 
+type tracebackError int
+
+const (
+	tracebackOK tracebackError = iota
+	tracebackUnknownPC
+	tracebackUnexpectedReturnPC
+	tracebackStuck
+)
+
 func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max int, callback func(*stkframe, unsafe.Pointer) bool, v unsafe.Pointer, flags uint) int {
 	if callback != nil && pcbuf != nil {
 		throw("unexpected: callback and pcbuf set")
@@ -17,6 +26,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		throw("gentraceback callback cannot be used with non-zero skip")
 	}
 
+	printing := callback == nil && pcbuf == nil
 	itr := tracebackIterator{
 		pc0:      pc0,
 		sp0:      sp0,
@@ -27,10 +37,7 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 		max:      max,
 		callback: *(*func(*stkframe, unsafe.Pointer) bool)(noescape(unsafe.Pointer(&callback))),
 		flags:    flags,
-		printing: callback == nil && pcbuf == nil,
-	}
-	if !itr.init() {
-		return 0
+		printing: printing,
 	}
 
 	for itr.Next() {
@@ -39,6 +46,19 @@ func gentraceback2(pc0, sp0, lr0 uintptr, gp *g, skip int, pcbuf *uintptr, max i
 				return itr.n
 			}
 		}
+	}
+
+	switch itr.Error() {
+	case tracebackUnknownPC:
+		if callback != nil || printing {
+			// TODO(fg) don't access itr state like this?
+			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(itr.frame.pc), "\n")
+			tracebackHexdump(itr.stack, &itr.frame, 0)
+		}
+		if callback != nil {
+			throw("unknown pc")
+		}
+		return 0 // tracebackUnknownPC happens in init()
 	}
 
 	if itr.printing {
@@ -103,6 +123,7 @@ type tracebackIterator struct {
 	callback      func(*stkframe, unsafe.Pointer) bool
 	flags         uint
 
+	initialized  bool
 	level        int32
 	nprint       int
 	frame        stkframe
@@ -114,6 +135,7 @@ type tracebackIterator struct {
 	lastFuncID   funcID
 	n            int
 	currentFrame stkframe // frame is already the next frame when Next() returns
+	error        tracebackError
 }
 
 func (itr *tracebackIterator) init() bool {
@@ -191,13 +213,7 @@ func (itr *tracebackIterator) init() bool {
 
 	f := findfunc(itr.frame.pc)
 	if !f.valid() {
-		if itr.callback != nil || itr.printing {
-			print("runtime: g ", itr.gp.goid, ": unknown pc ", hex(itr.frame.pc), "\n")
-			tracebackHexdump(itr.stack, &itr.frame, 0)
-		}
-		if itr.callback != nil {
-			throw("unknown pc")
-		}
+		itr.error = tracebackUnknownPC
 		return false
 	}
 	setFuncInfoNoWB(&itr.frame.fn, f)
@@ -208,6 +224,15 @@ func (itr *tracebackIterator) init() bool {
 }
 
 func (itr *tracebackIterator) Next() bool {
+	if !itr.initialized {
+		itr.initialized = true
+		if !itr.init() {
+			return false
+		}
+	}
+	if itr.error != 0 {
+		return false
+	}
 	if itr.n >= itr.max {
 		return false
 	}
@@ -603,6 +628,10 @@ func (itr *tracebackIterator) Next() bool {
 
 func (itr *tracebackIterator) Frame() *stkframe {
 	return &itr.currentFrame
+}
+
+func (itr *tracebackIterator) Error() tracebackError {
+	return itr.error
 }
 
 // setNoWB performs *dst = src without a write barrier.

--- a/src/runtime/traceback2.go
+++ b/src/runtime/traceback2.go
@@ -10,10 +10,18 @@ import (
 	"unsafe"
 )
 
+type tracebackState int
+
+const (
+	tracebackInit tracebackState = iota
+	tracebackNext
+	tracebackDone
+)
+
 type tracebackError int
 
 const (
-	tracebackOK tracebackError = iota
+	tracebackNoError tracebackError = iota
 	tracebackOwnStack
 	tracebackUnknownPC
 	tracebackUnexpectedSPWrite
@@ -134,6 +142,7 @@ type tracebackIterator struct {
 	callback      bool
 	flags         uint
 
+	state        tracebackState
 	initialized  bool
 	level        int32
 	nprint       int
@@ -149,7 +158,7 @@ type tracebackIterator struct {
 	error        tracebackError
 }
 
-func (itr *tracebackIterator) init() bool {
+func (itr *tracebackIterator) init() tracebackError {
 	// Don't call this "g"; it's too easy get "g" and "gp" confused.
 	if ourg := getg(); ourg == itr.gp && ourg == ourg.m.curg {
 		// The starting sp has been passed in as a uintptr, and the caller may
@@ -165,8 +174,7 @@ func (itr *tracebackIterator) init() bool {
 		// accepts an sp for the current goroutine (typically obtained by
 		// calling getcallersp) must not run on that goroutine's stack but
 		// instead on the g0 stack.
-		itr.error = tracebackOwnStack
-		return false
+		return tracebackOwnStack
 	}
 	itr.level, _, _ = gotraceback()
 
@@ -225,28 +233,42 @@ func (itr *tracebackIterator) init() bool {
 
 	f := findfunc(itr.frame.pc)
 	if !f.valid() {
-		itr.error = tracebackUnknownPC
-		return false
+		return tracebackUnknownPC
 	}
 	setFuncInfoNoWB(&itr.frame.fn, f)
 
 	itr.lastFuncID = funcID_normal
 
-	return true
+	return tracebackNoError
 }
 
 func (itr *tracebackIterator) Next() bool {
-	if !itr.initialized {
-		itr.initialized = true
-		if !itr.init() {
+	for {
+		switch itr.state {
+		case tracebackDone:
 			return false
+		case tracebackInit:
+			if itr.error = itr.init(); itr.error != tracebackNoError {
+				itr.state = tracebackDone
+				return false
+			}
+			itr.state = tracebackNext
+		case tracebackNext:
+			var more bool
+			more, itr.error = itr.next()
+			if !more || itr.error != tracebackNoError {
+				itr.state = tracebackDone
+			}
+			return more
+		default:
+			throw("bug")
 		}
 	}
-	if itr.error != 0 {
-		return false
-	}
+}
+
+func (itr *tracebackIterator) next() (bool, tracebackError) {
 	if itr.n >= itr.max {
-		return false
+		return false, tracebackNoError
 	}
 
 	// Typically:
@@ -259,7 +281,7 @@ func (itr *tracebackIterator) Next() bool {
 	if f.pcsp == 0 {
 		// No frame information, must be external function, like race support.
 		// See golang.org/issue/13568.
-		return false
+		return false, tracebackNoError
 	}
 
 	// Compute function info flags.
@@ -315,7 +337,7 @@ func (itr *tracebackIterator) Next() bool {
 					// instruction opens the frame), therefore no way
 					// to check.
 					flag &^= funcFlag_SPWRITE
-					return false
+					return false, tracebackNoError
 				}
 				setGNoWB(&itr.gp, itr.gp.m.curg)
 				itr.frame.sp = itr.gp.sched.sp
@@ -354,8 +376,7 @@ func (itr *tracebackIterator) Next() bool {
 		// at the bottom frame of the stack. But farther up the stack we'd better not
 		// find any.
 		if itr.callback {
-			itr.error = tracebackUnexpectedSPWrite
-			return false
+			return false, tracebackUnexpectedSPWrite
 		}
 		itr.frame.lr = 0
 		flr = funcInfo{}
@@ -605,7 +626,7 @@ func (itr *tracebackIterator) Next() bool {
 
 	// Do not unwind past the bottom of the stack.
 	if !flr.valid() {
-		return false
+		return false, tracebackNoError
 	}
 
 	if itr.frame.pc == itr.frame.lr && itr.frame.sp == itr.frame.fp {
@@ -635,7 +656,7 @@ func (itr *tracebackIterator) Next() bool {
 			itr.frame.lr = x
 		}
 	}
-	return itr.n < itr.max
+	return itr.n < itr.max, tracebackNoError
 }
 
 func (itr *tracebackIterator) Frame() *stkframe {


### PR DESCRIPTION
The goal is to refactor `gentraceback` to use a more high-level iterator API internally. E.g. something like this:

```go
itr := newTracebackIterator(...)
for n := 0; n < max; {
	if !itr.Next() {
		break
	} else if skip > 0 {
		skip--
	} else {
		(*[1 << 20]uintptr)(unsafe.Pointer(pcbuf))[n] = itr.Frame().PC
		n++
	}
}
```

This is mostly a learning project for me. I'm probably in way over my head and am doubtful the result will be good enough for upstream 🙈.

See https://github.com/golang/go/issues/54466

[<img src="https://user-images.githubusercontent.com/15000/204651986-3bddfc0c-71f0-4271-ac7b-b30412e7043b.png" width=400 />](https://twitter.com/felixge/status/1597674689098579968)
